### PR TITLE
Explicitly pass in owner as param [TAC-204]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Run Forge build
         run: forge build --sizes
+        
+      - name: Run Forge lints
+        run: forge lint -vvv
 
       - name: Run Forge tests
         run: forge test -vvv

--- a/script/deploy/OprfKeyRegistry.s.sol
+++ b/script/deploy/OprfKeyRegistry.s.sol
@@ -14,6 +14,7 @@ contract DeployOprfKeyRegistryScript is Script {
     function run() public {
         vm.startBroadcast();
 
+        address owner = msg.sender;
         address taceoAdminAddress = vm.envAddress("TACEO_ADMIN_ADDRESS");
         address keyGenVerifierAddress = vm.envAddress("KEY_GEN_VERIFIER_ADDRESS");
         uint256 threshold = vm.envUint("THRESHOLD");
@@ -28,7 +29,7 @@ contract DeployOprfKeyRegistryScript is Script {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
+            OprfKeyRegistry.initialize.selector, owner, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);

--- a/script/deploy/OprfKeyRegistryWithDeps.s.sol
+++ b/script/deploy/OprfKeyRegistryWithDeps.s.sol
@@ -30,6 +30,7 @@ contract DeployOprfKeyRegistryWithDepsScript is Script {
     function run() public {
         vm.startBroadcast();
 
+        address owner = msg.sender;
         address taceoAdminAddress = vm.envAddress("TACEO_ADMIN_ADDRESS");
         uint256 threshold = vm.envUint("THRESHOLD");
         uint256 numPeers = vm.envUint("NUM_PEERS");
@@ -39,7 +40,7 @@ contract DeployOprfKeyRegistryWithDepsScript is Script {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
+            OprfKeyRegistry.initialize.selector, owner, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);

--- a/script/test/TestSetup.s.sol
+++ b/script/test/TestSetup.s.sol
@@ -34,6 +34,7 @@ contract TestSetupScript is Script {
         uint256 numPeers = vm.envUint("NUM_PEERS");
         address keyGenVerifierAddress = deployGroth16VerifierKeyGen(threshold, numPeers);
         address taceoAdminAddress = vm.envAddress("TACEO_ADMIN_ADDRESS");
+        address owner = msg.sender;
 
         address[] memory participants = vm.envAddress("PARTICIPANT_ADDRESSES", ",");
         for (uint256 i = 0; i < participants.length; i++) {
@@ -44,7 +45,7 @@ contract TestSetupScript is Script {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
+            OprfKeyRegistry.initialize.selector, owner, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -123,16 +123,19 @@ contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgrade
     }
 
     /// @notice Initializer function to set up the OprfKeyRegistry contract, this is not a constructor due to the use of upgradeable proxies.
+    /// @param _owner The address of the contract owner, passed explicitly in initialize.
     /// @param _keygenAdmin The address of the key generation administrator, only party that is allowed to start key generation processes.
     /// @param _keyGenVerifierAddress The address of the Groth16 verifier contract for key generation (needs to be compatible with threshold numPeers values).
     /// @param _threshold The threshold number of peers required for key generation.
     /// @param _numPeers The number of peers participating in the key generation.
-    function initialize(address _keygenAdmin, address _keyGenVerifierAddress, uint16 _threshold, uint16 _numPeers)
-        public
-        virtual
-        initializer
-    {
-        __Ownable_init(msg.sender);
+    function initialize(
+        address _owner,
+        address _keygenAdmin,
+        address _keyGenVerifierAddress,
+        uint16 _threshold,
+        uint16 _numPeers
+    ) public virtual initializer {
+        __Ownable_init(_owner);
         __Ownable2Step_init();
         keygenAdmins[_keygenAdmin] = true;
         amountKeygenAdmins += 1;

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -9,8 +9,6 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 
 uint256 constant PUBLIC_INPUT_LENGTH_KEYGEN_13 = 24;
 uint256 constant PUBLIC_INPUT_LENGTH_KEYGEN_25 = 36;
-uint256 constant PUBLIC_INPUT_LENGTH_NULLIFIER = 13;
-uint256 constant AUTHENTICATOR_MERKLE_TREE_DEPTH = 30;
 
 interface IVerifierKeyGen13 {
     function verifyCompressedProof(

--- a/test/OprfKeyRegistry.admin.t.sol
+++ b/test/OprfKeyRegistry.admin.t.sol
@@ -23,6 +23,7 @@ contract OprfKeyRegistryTest is Test {
     address bob = address(0x2);
     address carol = address(0x3);
     address taceoAdmin = address(0x4);
+    address initOwner = 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496; // the default addr of this test contract
 
     function setUp() public {
         verifierKeyGen = new VerifierKeyGen13();
@@ -30,7 +31,7 @@ contract OprfKeyRegistryTest is Test {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);
@@ -49,7 +50,7 @@ contract OprfKeyRegistryTest is Test {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         // Deploy proxy
         ERC1967Proxy proxyTest = new ERC1967Proxy(address(implementation), initData);
@@ -60,6 +61,7 @@ contract OprfKeyRegistryTest is Test {
         assertEq(oprfKeyRegistryTest.threshold(), 2);
         assertEq(oprfKeyRegistryTest.numPeers(), 3);
         assert(!oprfKeyRegistryTest.isContractReady());
+        assert(oprfKeyRegistryTest.owner() == initOwner);
 
         // TODO call other functions to check that it reverts correctly
     }
@@ -69,7 +71,7 @@ contract OprfKeyRegistryTest is Test {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         // Deploy proxy
         ERC1967Proxy proxyTest = new ERC1967Proxy(address(implementation), initData);
@@ -115,7 +117,7 @@ contract OprfKeyRegistryTest is Test {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         // Deploy proxy
         ERC1967Proxy proxyTest = new ERC1967Proxy(address(implementation), initData);
@@ -136,7 +138,7 @@ contract OprfKeyRegistryTest is Test {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         // Deploy proxy
         ERC1967Proxy proxyTest = new ERC1967Proxy(address(implementation), initData);
@@ -198,7 +200,7 @@ contract OprfKeyRegistryTest is Test {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         // Deploy proxy
         ERC1967Proxy proxyTest = new ERC1967Proxy(address(implementation), initData);
@@ -294,4 +296,3 @@ contract OprfKeyRegistryTest is Test {
         vm.stopPrank();
     }
 }
-

--- a/test/OprfKeyRegistry.keygen.t.sol
+++ b/test/OprfKeyRegistry.keygen.t.sol
@@ -23,6 +23,7 @@ contract OprfKeyRegistryKeyGenTest is Test {
     address bob = address(0x2);
     address carol = address(0x3);
     address taceoAdmin = address(0x4);
+    address initOwner = 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496; // the default addr of this test contract
 
     function setUp() public {
         verifierKeyGen = new VerifierKeyGen13();
@@ -30,7 +31,7 @@ contract OprfKeyRegistryKeyGenTest is Test {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);
@@ -321,4 +322,3 @@ contract OprfKeyRegistryKeyGenTest is Test {
         vm.stopPrank();
     }
 }
-

--- a/test/OprfKeyRegistryUpgrade.t.sol
+++ b/test/OprfKeyRegistryUpgrade.t.sol
@@ -49,7 +49,7 @@ contract OprfKeyRegistryUpgradeTest is Test {
     address bob = address(0x2);
     address carol = address(0x3);
     address taceoAdmin = address(0x4);
-    address initOwner = 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496;
+    address initOwner = 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496; // the default addr of this test contract
 
     function setUp() public {
         verifierKeyGen = new VerifierKeyGen13();
@@ -57,7 +57,7 @@ contract OprfKeyRegistryUpgradeTest is Test {
         OprfKeyRegistry implementation = new OprfKeyRegistry();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
-            OprfKeyRegistry.initialize.selector, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);
@@ -256,4 +256,3 @@ contract OprfKeyRegistryUpgradeTest is Test {
         assertEq(oprfKeyNew.y, Contributions.SHOULD_OPRF_PUBLIC_KEY_Y);
     }
 }
-


### PR DESCRIPTION
Move the owner of the contract from msg.sender to an explicit variable.
Also removes some leftover constants
