### PR TITLE
feat: emit an event if one of the registered OPRF peers changes.

### DIFF
--- a/src/OprfKeyGen.sol
+++ b/src/OprfKeyGen.sol
@@ -87,6 +87,8 @@ library OprfKeyGen {
     event KeyGenAdminRevoked(address indexed admin);
     event KeyGenAdminRegistered(address indexed admin);
     event NotEnoughProducers(uint160 indexed oprfKeyId);
+    // peer events
+    event OprfPeerChanged(uint16 partyId, address oldPeer, address newPeer);
 
     /// @notice Initializes the internal state for a new OPRF key-generation process.
     ///

--- a/src/OprfKeyGen.sol
+++ b/src/OprfKeyGen.sol
@@ -88,7 +88,7 @@ library OprfKeyGen {
     event KeyGenAdminRegistered(address indexed admin);
     event NotEnoughProducers(uint160 indexed oprfKeyId);
     // peer events
-    event OprfPeerChanged(uint16 partyId, address oldPeer, address newPeer);
+    event OprfPeerChanged(uint16 indexed partyId, address indexed oldPeer, address indexed newPeer);
 
     /// @notice Initializes the internal state for a new OPRF key-generation process.
     ///

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -214,6 +214,7 @@ contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgrade
             address oldPeerAddress = peerAddresses.length > i ? peerAddresses[i] : address(0);
             if (oldPeerAddress != _peerAddresses[i]) {
                 // safe cast: numPeers is uint16 and we check that _peerAddresses.length == numPeers above
+                // forge-lint: disable-next-line(unsafe-typecast)
                 emit OprfKeyGen.OprfPeerChanged(uint16(i), oldPeerAddress, _peerAddresses[i]);
             }
         }

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -209,6 +209,14 @@ contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgrade
                 }
             }
         }
+        // emit event with the new peer addresses
+        for (uint256 i = 0; i < _peerAddresses.length; ++i) {
+            address oldPeerAddress = peerAddresses.length > i ? peerAddresses[i] : address(0);
+            if (oldPeerAddress != _peerAddresses[i]) {
+                // safe cast: numPeers is uint16 and we check that _peerAddresses.length == numPeers above
+                emit OprfKeyGen.OprfPeerChanged(uint16(i), oldPeerAddress, _peerAddresses[i]);
+            }
+        }
         // delete the old participants
         for (uint256 i = 0; i < peerAddresses.length; ++i) {
             delete addressToPeer[peerAddresses[i]];

--- a/test/OprfKeyRegistry.admin.t.sol
+++ b/test/OprfKeyRegistry.admin.t.sol
@@ -44,7 +44,9 @@ contract OprfKeyRegistryTest is Test {
         peerAddresses[2] = carol;
         vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(0, address(0), alice);
+        vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(1, address(0), bob);
+        vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(2, address(0), carol);
         oprfKeyRegistry.registerOprfPeers(peerAddresses);
     }
@@ -90,7 +92,9 @@ contract OprfKeyRegistryTest is Test {
         assert(!oprfKeyRegistryTest.isContractReady());
         vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(0, address(0), alice);
+        vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(1, address(0), bob);
+        vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(2, address(0), carol);
         oprfKeyRegistryTest.registerOprfPeers(peerAddresses);
 
@@ -185,7 +189,9 @@ contract OprfKeyRegistryTest is Test {
         // update
         vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(0, alice, bob);
+        vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(1, bob, carol);
+        vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(2, carol, taceoAdmin);
         oprfKeyRegistry.registerOprfPeers(peerAddresses);
 
@@ -205,16 +211,16 @@ contract OprfKeyRegistryTest is Test {
         vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.NotAParticipant.selector));
         oprfKeyRegistry.getPartyIdForParticipant(alice);
         vm.stopPrank();
-        
+
         address[] memory peerAddresses2 = new address[](3);
         peerAddresses2[0] = bob;
         peerAddresses2[1] = carol;
         peerAddresses2[2] = alice;
-        
+
         vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.OprfPeerChanged(2, taceoAdmin, alice);
         oprfKeyRegistry.registerOprfPeers(peerAddresses2);
-        
+
         vm.prank(bob);
         assertEq(oprfKeyRegistry.getPartyIdForParticipant(bob), 0);
         vm.stopPrank();

--- a/test/OprfKeyRegistry.admin.t.sol
+++ b/test/OprfKeyRegistry.admin.t.sol
@@ -42,6 +42,10 @@ contract OprfKeyRegistryTest is Test {
         peerAddresses[0] = alice;
         peerAddresses[1] = bob;
         peerAddresses[2] = carol;
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.OprfPeerChanged(0, address(0), alice);
+        emit OprfKeyGen.OprfPeerChanged(1, address(0), bob);
+        emit OprfKeyGen.OprfPeerChanged(2, address(0), carol);
         oprfKeyRegistry.registerOprfPeers(peerAddresses);
     }
 
@@ -84,6 +88,10 @@ contract OprfKeyRegistryTest is Test {
 
         // check that not ready
         assert(!oprfKeyRegistryTest.isContractReady());
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.OprfPeerChanged(0, address(0), alice);
+        emit OprfKeyGen.OprfPeerChanged(1, address(0), bob);
+        emit OprfKeyGen.OprfPeerChanged(2, address(0), carol);
         oprfKeyRegistryTest.registerOprfPeers(peerAddresses);
 
         // check that ready after call
@@ -175,6 +183,10 @@ contract OprfKeyRegistryTest is Test {
         peerAddresses[2] = taceoAdmin;
 
         // update
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.OprfPeerChanged(0, alice, bob);
+        emit OprfKeyGen.OprfPeerChanged(1, bob, carol);
+        emit OprfKeyGen.OprfPeerChanged(2, carol, taceoAdmin);
         oprfKeyRegistry.registerOprfPeers(peerAddresses);
 
         vm.prank(bob);
@@ -192,6 +204,27 @@ contract OprfKeyRegistryTest is Test {
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.NotAParticipant.selector));
         oprfKeyRegistry.getPartyIdForParticipant(alice);
+        vm.stopPrank();
+        
+        address[] memory peerAddresses2 = new address[](3);
+        peerAddresses2[0] = bob;
+        peerAddresses2[1] = carol;
+        peerAddresses2[2] = alice;
+        
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.OprfPeerChanged(2, taceoAdmin, alice);
+        oprfKeyRegistry.registerOprfPeers(peerAddresses2);
+        
+        vm.prank(bob);
+        assertEq(oprfKeyRegistry.getPartyIdForParticipant(bob), 0);
+        vm.stopPrank();
+
+        vm.prank(carol);
+        assertEq(oprfKeyRegistry.getPartyIdForParticipant(carol), 1);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        assertEq(oprfKeyRegistry.getPartyIdForParticipant(alice), 2);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Event-only behavioral change during peer registration; core keygen/reshare logic and state transitions are unchanged, with coverage added via tests.
> 
> **Overview**
> Adds a new `OprfKeyGen.OprfPeerChanged(partyId, oldPeer, newPeer)` event and emits it from `OprfKeyRegistry.registerOprfPeers` for each party whose registered address is added/updated (including initial registration via `address(0)` as the old peer).
> 
> Updates the admin registry tests to assert the new event emissions for both first-time peer registration and subsequent peer updates (including partial changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a3d6a1cf4485eff301931408643cc761bb838cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->