### PR TITLE
test: add wrong-round event for key-registry-mock

### DIFF
--- a/test/TestOprfKeyRegistry.sol
+++ b/test/TestOprfKeyRegistry.sol
@@ -6,6 +6,7 @@ import {OprfKeyGen} from "../src/OprfKeyGen.sol";
 import {OprfKeyRegistry, IVerifierKeyGen13, PUBLIC_INPUT_LENGTH_KEYGEN_13} from "../src/OprfKeyRegistry.sol";
 
 uint256 constant INVALID_PROOF = 43;
+uint256 constant WRONG_ROUND_LOAD_PEER_PUBLIC_KEYS = 44;
 
 contract TestOprfKeyRegistry is OprfKeyRegistry {
     function emitDeleteEvent(uint160 oprfKeyId) public {
@@ -20,6 +21,9 @@ contract TestOprfKeyRegistry is OprfKeyRegistry {
         onlyProxy
         returns (BabyJubJub.Affine[] memory)
     {
+        if (WRONG_ROUND_LOAD_PEER_PUBLIC_KEYS == oprfKeyId) {
+            revert WrongRound(OprfKeyGen.Round.THREE);
+        }
         if (oprfKeyId == INVALID_PROOF) {
             // producer
             BabyJubJub.Affine memory p0 = BabyJubJub.Affine({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that adds an additional failure mode to a mock contract; no production logic is modified.
> 
> **Overview**
> Updates the `TestOprfKeyRegistry` test mock to add a new sentinel key id (`WRONG_ROUND_LOAD_PEER_PUBLIC_KEYS`) that forces `loadPeerPublicKeysForProducers` to revert with `WrongRound(OprfKeyGen.Round.THREE)`.
> 
> This enables tests to exercise and assert wrong-round error handling for the peer public key loading path without changing production contract behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1aab0f664537efaac5e77152c9faa05ad4dbd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->