### PR TITLE
test: add finalize_event for mock contract

### DIFF
--- a/test/TestOprfKeyRegistry.sol
+++ b/test/TestOprfKeyRegistry.sol
@@ -13,6 +13,10 @@ contract TestOprfKeyRegistry is OprfKeyRegistry {
         emit OprfKeyGen.KeyDeletion(oprfKeyId);
     }
 
+    function emitSecretGenFinalize(uint160 oprfKeyId, uint32 epoch) public {
+        emit OprfKeyGen.SecretGenFinalize(oprfKeyId, epoch);
+    }
+
     function loadPeerPublicKeysForProducers(uint160 oprfKeyId)
         public
         view


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that only adds an event-emitting helper and does not affect production contract logic or state.
> 
> **Overview**
> Adds a new helper function `emitSecretGenFinalize(oprfKeyId, epoch)` to `TestOprfKeyRegistry` so tests can manually emit `OprfKeyGen.SecretGenFinalize` in addition to the existing key deletion event emitter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da131b3f589fbef71654c8bb34f300a5aee957b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->