### PR TITLE
audits/february 26

### DIFF
--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -330,6 +330,9 @@ contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgrade
         if (st.currentRound == OprfKeyGen.Round.NOT_STARTED) {
             revert UnknownId(oprfKeyId);
         }
+        if (st.currentRound == OprfKeyGen.Round.DELETED) {
+            revert DeletedId(oprfKeyId);
+        }
         st.reset(numPeers, peerAddresses);
         emit OprfKeyGen.KeyGenAbort(oprfKeyId);
     }

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -33,6 +33,11 @@ interface IOprfKeyRegistry {
     function revokeKeyGenAdmin(address _keygenAdmin) external;
 }
 
+
+/// @dev This contract does not include a storage gap. Upgrades are expected to be
+/// implemented via inheritance from this contract, which preserves the storage
+/// layout. No guarantees are provided for upgrade patterns that do not inherit
+/// from this contract.
 contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgradeable, UUPSUpgradeable {
     using BabyJubJub for BabyJubJub.Affine;
     using OprfKeyGen for OprfKeyGen.OprfKeyGenState;
@@ -881,19 +886,13 @@ contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgrade
      */
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
 
-    ////////////////////////////////////////////////////////////
-    //                    Storage Gap                         //
-    ////////////////////////////////////////////////////////////
-
-    /**
+    /* Storage gap:
+     * We do not include a storage gap due to the way we expect upgrades to work in practice.
+     * All upgrades are expected to be implemented as child contracts inheriting from this
+     * contract, which preserves the original storage layout and appends any new state
+     * variables in the derived contract.
      *
-     *
-     * @dev Storage gap to allow for future upgrades without storage collisions
-     *
-     *
-     * This is set to take a total of 50 storage slots for future state variables
-     *
-     *
+     * No guarantees are made for contracts that rely on this contract’s storage layout
+     * without inheriting from it.
      */
-    uint256[40] private __gap;
 }

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -33,7 +33,6 @@ interface IOprfKeyRegistry {
     function revokeKeyGenAdmin(address _keygenAdmin) external;
 }
 
-
 /// @dev This contract does not include a storage gap. Upgrades are expected to be
 /// implemented via inheritance from this contract, which preserves the storage
 /// layout. No guarantees are provided for upgrade patterns that do not inherit
@@ -768,6 +767,8 @@ contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgrade
         OprfKeyGen.OprfKeyGenState storage st = runningKeyGens[oprfKeyId];
         // check that we are in correct round
         if (st.currentRound != OprfKeyGen.Round.ONE) revert WrongRound(st.currentRound);
+        // check that the provided ephPubKey is distinct to prevent replay attacks
+        _ephKeyUniqueCheck(st, data.ephPubKey);
         // check that we don't have double submission
         if (!st.round1[partyId].commShare.isEmpty()) revert AlreadySubmitted();
         st.round1[partyId] = data;
@@ -870,6 +871,24 @@ contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgrade
         }
     }
 
+    // Performs a uniqueness check for the provided ephemeral public key,
+    // which is a BabyJubJub point in affine coordinates.
+    //
+    // This method iterates over all ephemeral public keys submitted in round 1
+    // (including uninitialized entries) and checks that the provided public key
+    // (`needle`) is unique.
+    function _ephKeyUniqueCheck(OprfKeyGen.OprfKeyGenState storage st, BabyJubJub.Affine calldata needle)
+        internal
+        view
+        virtual
+    {
+        // Ensure that the provided ephemeral public key is distinct to prevent replay attacks.
+        for (uint256 i = 0; i < numPeers; ++i) {
+            if (BabyJubJub.isEqual(st.round1[i].ephPubKey, needle)) {
+                revert BadContribution();
+            }
+        }
+    }
     ////////////////////////////////////////////////////////////
     //                    Upgrade Authorization               //
     ////////////////////////////////////////////////////////////

--- a/test/OprfKeyRegistry.keygen.t.sol
+++ b/test/OprfKeyRegistry.keygen.t.sol
@@ -144,7 +144,6 @@ contract OprfKeyRegistryKeyGenTest is Test {
     }
 
     function testAbortAfterDeleteShouldFail() public {
-
         uint160 oprfKeyId = 42;
         testKeyGen();
 
@@ -230,6 +229,79 @@ contract OprfKeyRegistryKeyGenTest is Test {
 
         deleteOprfKey(oprfKeyId);
         checkGeneratedIsDeleted(oprfKeyId);
+    }
+
+    function testKeyGenRound1Replay() public {
+        uint160 oprfKeyId = 42;
+        initKeyGen(oprfKeyId);
+        vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.KeyGenConfirmation(oprfKeyId, 1, 1, 0);
+        oprfKeyRegistry.addRound1KeyGenContribution(oprfKeyId, Contributions.bobKeyGenRound1Contribution());
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.BadContribution.selector));
+        oprfKeyRegistry.addRound1KeyGenContribution(oprfKeyId, Contributions.bobKeyGenRound1Contribution());
+        vm.stopPrank();
+    }
+
+    function testKeyGenRound2Replay() public {
+        uint160 oprfKeyId = 42;
+        initKeyGen(oprfKeyId);
+        keyGenRound1Contributions(oprfKeyId);
+
+        vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.KeyGenConfirmation(oprfKeyId, 1, 2, 0);
+        oprfKeyRegistry.addRound2Contribution(oprfKeyId, Contributions.bobKeyGenRound2Contribution());
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(VerifierKeyGen13.ProofInvalid.selector));
+        oprfKeyRegistry.addRound2Contribution(oprfKeyId, Contributions.bobKeyGenRound2Contribution());
+        vm.stopPrank();
+    }
+
+    function testKeyGenRound2ReplayButDistinctKey() public {
+        uint160 oprfKeyId = 42;
+        initKeyGen(oprfKeyId);
+        vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.KeyGenConfirmation(oprfKeyId, 1, 1, 0);
+        oprfKeyRegistry.addRound1KeyGenContribution(oprfKeyId, Contributions.bobKeyGenRound1Contribution());
+        vm.stopPrank();
+
+        OprfKeyGen.Round1Contribution memory bobReplay = Contributions.bobKeyGenRound1Contribution();
+        bobReplay.ephPubKey = Contributions.aliceKeyGenRound1Contribution().ephPubKey;
+
+        // this works now
+        vm.prank(alice);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.KeyGenConfirmation(oprfKeyId, 0, 1, 0);
+        oprfKeyRegistry.addRound1KeyGenContribution(oprfKeyId, bobReplay);
+        vm.stopPrank();
+
+        vm.prank(carol);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.SecretGenRound2(oprfKeyId, 0);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.KeyGenConfirmation(oprfKeyId, 2, 1, 0);
+        oprfKeyRegistry.addRound1KeyGenContribution(oprfKeyId, Contributions.carolKeyGenRound1Contribution());
+        vm.stopPrank();
+
+        // Bob sends his proof
+        vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.KeyGenConfirmation(oprfKeyId, 1, 2, 0);
+        oprfKeyRegistry.addRound2Contribution(oprfKeyId, Contributions.bobKeyGenRound2Contribution());
+        vm.stopPrank();
+
+        // Alice can't just simply replay
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(VerifierKeyGen13.ProofInvalid.selector));
+        oprfKeyRegistry.addRound2Contribution(oprfKeyId, Contributions.bobKeyGenRound2Contribution());
+        vm.stopPrank();
     }
 
     function keyGenRound1Contributions(uint160 oprfKeyId) internal {

--- a/test/OprfKeyRegistry.keygen.t.sol
+++ b/test/OprfKeyRegistry.keygen.t.sol
@@ -143,6 +143,21 @@ contract OprfKeyRegistryKeyGenTest is Test {
         checkGeneratedKey(oprfKeyId, 0);
     }
 
+    function testAbortAfterDeleteShouldFail() public {
+
+        uint160 oprfKeyId = 42;
+        testKeyGen();
+
+        vm.prank(taceoAdmin);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.KeyDeletion(oprfKeyId);
+        oprfKeyRegistry.deleteOprfPublicKey(oprfKeyId);
+        vm.prank(taceoAdmin);
+        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.DeletedId.selector, oprfKeyId));
+        oprfKeyRegistry.abortKeyGen(oprfKeyId);
+        vm.stopPrank();
+    }
+
     function testDeleteBeforeRound1() public {
         uint160 oprfKeyId = 42;
         initKeyGen(oprfKeyId);


### PR DESCRIPTION
- **refactor!: remove the storage gap from key-registry**
- **fix: prevents reseting a deleted key if abort is called**
- **fix: adds uniquness check for eph public keys to prevent replay attacks**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches upgradeability/storage-layout expectations and adds new validation in the key-generation path; mistakes could break proxy upgrades or reject valid contributions during round 1.
> 
> **Overview**
> Improves `OprfKeyRegistry` safety around key lifecycle and MPC contributions.
> 
> `abortKeyGen` now reverts for already-deleted key IDs (instead of resetting deleted state), and round-1 submissions now enforce *uniqueness* of `ephPubKey` across all parties to prevent replaying another peer’s ephemeral key. The upgrade `__gap` storage array is removed and replaced with explicit documentation that future upgrades are expected to be implemented via inheritance to preserve storage layout.
> 
> Tests add coverage for abort-after-delete reverting and for replay scenarios across round 1/2 contributions (including a case where replayed data is accepted only when the ephemeral key is changed).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa37efce34346cf59c488ce850346c4c34c424a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->