### PR TITLE
build(ci): add upgradeable proxy check in ci

### DIFF
--- a/.github/workflows/is_upgradable.yml
+++ b/.github/workflows/is_upgradable.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Proxy Upgrade Checks
 
 permissions: {}
 

--- a/.github/workflows/is_upgradable.yml
+++ b/.github/workflows/is_upgradable.yml
@@ -1,0 +1,41 @@
+name: CI
+
+permissions: {}
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: OpenZeppelin Upgrade Validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Setup Node.js (includes npx)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Show Node and npx versions
+        run: |
+          node --version
+          npx --version
+
+      - name: Build contracts
+        run: forge clean && forge install && forge build
+
+      - name: Run OpenZeppelin upgrades validation
+        run: npx @openzeppelin/upgrades-core validate --unsafeAllowLinkedLibraries --exclude "**/*.t.sol"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Contract Tests
 
 permissions: {}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check:
-    name: Foundry project
+    name: Contract Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,8 @@ optimizer_runs = 10000
 via_ir = true
 memory_limit = 1073741824
 gas_limit = "18446744073709551615"
+build_info = true
+extra_output = ["storageLayout"]
 
 [lint]
 exclude_lints = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/config-only changes; primary risk is additional build metadata and a new validation step causing noisy CI failures or longer runtimes.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`is_upgradable.yml`) that builds the Foundry project and runs `@openzeppelin/upgrades-core validate` (with linked-library allowance and test-file exclusion) on pushes/PRs/manual runs.
> 
> Updates `foundry.toml` to emit `build_info` and `storageLayout` output needed for upgrade validation, and renames the existing workflow display name from `CI` to **Contract Tests** for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59771fb448638f17aaaef8424644c62f7df807e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->