### PR TITLE
Upgrade Proxy Script

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,42 +26,72 @@ show-contract-methods:
     forge inspect src/OprfKeyRegistry.sol:OprfKeyRegistry methodIdentifiers
 
 [group('deploy')]
+[working-directory("script/deploy")]
+deploy-oprf-key-registry-impl-dry-run *args:
+    forge script OprfKeyRegistryImpl.s.sol -vvvvv {{ args }}
+
+[group('deploy')]
+[working-directory("script/deploy")]
+deploy-oprf-key-registry-impl *args:
+    forge script OprfKeyRegistryImpl.s.sol --broadcast --interactives 1 -vvvvv {{ args }} --rpc-url $RPC_URL --verify --verifier etherscan --etherscan-api-key $ETHERSCAN_API_KEY
+
+[group('deploy')]
+[working-directory("script/deploy")]
+upgrade-oprf-key-registry-dry-run *args:
+    forge script UpgradeOprfKeyRegistry.s.sol -vvvvv {{ args }}
+
+[group('deploy')]
+[working-directory("script/deploy")]
+upgrade-oprf-key-registry *args:
+    forge script UpgradeOprfKeyRegistry.s.sol --broadcast --interactives 1 -vvvvv {{ args }} --rpc-url $RPC_URL --verify --verifier etherscan --etherscan-api-key $ETHERSCAN_API_KEY
+
+[group('deploy')]
+[working-directory("script/deploy")]
 deploy-oprf-key-registry-with-deps-dry-run *args:
     forge script OprfKeyRegistryWithDeps.s.sol -vvvvv {{ args }}
 
 [group('deploy')]
+[working-directory("script/deploy")]
 deploy-oprf-key-registry-with-deps *args:
     forge script OprfKeyRegistryWithDeps.s.sol --broadcast --interactives 1 -vvvvv {{ args }} --rpc-url $RPC_URL --verify --verifier etherscan --etherscan-api-key $ETHERSCAN_API_KEY
 
 [group('deploy')]
+[working-directory("script/deploy")]
 deploy-oprf-key-registry-dry-run *args:
     forge script OprfKeyRegistry.s.sol -vvvvv {{ args }}
 
 [group('deploy')]
+[working-directory("script/deploy")]
 deploy-oprf-key-registry *args:
     forge script OprfKeyRegistry.s.sol --broadcast --interactives 1 -vvvvv {{ args }} --rpc-url $RPC_URL --verify --verifier etherscan --etherscan-api-key $ETHERSCAN_API_KEY
 
 [group('contract')]
+[working-directory("script")]
 register-participants *args:
     forge script RegisterParticipants.s.sol --broadcast --interactives 1 -vvvvv {{ args }} --rpc-url $RPC_URL
 
 [group('contract')]
+[working-directory("script")]
 register-participants-dry-run *args:
     forge script RegisterParticipants.s.sol -vvvvv {{ args }}
 
 [group('contract')]
+[working-directory("script")]
 revoke-key-gen-admin-dry-run *args:
     forge script RevokeKeyGenAdmin.s.sol -vvvvv {{ args }}
 
 [group('contract')]
+[working-directory("script/deploy")]
 revoke-key-gen-admin *args:
     forge script RevokeKeyGenAdmin.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
 
 [group('contract')]
+[working-directory("script")]
 register-key-gen-admin-dry-run *args:
     forge script RegisterKeyGenAdmin.s.sol -vvvvv {{ args }}
 
 [group('contract')]
+[working-directory("script")]
 register-key-gen-admin *args:
     forge script RegisterKeyGenAdmin.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
 

--- a/justfile
+++ b/justfile
@@ -81,7 +81,7 @@ revoke-key-gen-admin-dry-run *args:
     forge script RevokeKeyGenAdmin.s.sol -vvvvv {{ args }}
 
 [group('contract')]
-[working-directory("script/deploy")]
+[working-directory("script")]
 revoke-key-gen-admin *args:
     forge script RevokeKeyGenAdmin.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
 
@@ -96,21 +96,26 @@ register-key-gen-admin *args:
     forge script RegisterKeyGenAdmin.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
 
 [group('anvil')]
+[working-directory("script/deploy")]
 deploy-oprf-key-registry-with-deps-anvil:
     TACEO_ADMIN_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 THRESHOLD=2 NUM_PEERS=3 forge script OprfKeyRegistryWithDeps.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 [group('anvil')]
+[working-directory("script/deploy")]
 deploy-oprf-key-registry-anvil:
     TACEO_ADMIN_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 THRESHOLD=2 NUM_PEERS=3 forge script OprfKeyRegistry.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 [group('anvil')]
+[working-directory("script")]
 register-participants-anvil:
     PARTICIPANT_ADDRESSES=0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 forge script RegisterParticipants.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 [group('anvil')]
+[working-directory("script")]
 revoke-key-gen-admin-anvil:
     forge script RevokeKeyGenAdmin.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 [group('anvil')]
+[working-directory("script")]
 register-key-gen-admin-anvil:
     forge script RegisterKeyGenAdmin.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/justfile
+++ b/justfile
@@ -1,0 +1,86 @@
+[private]
+default:
+    @just --justfile {{ justfile() }} --list --list-heading $'Project commands:\n'
+
+[group('build')]
+export-contract-abi:
+    forge build --silent && jq '.abi' out/OprfKeyRegistry.sol/OprfKeyRegistry.json > ../oprf-types/OprfKeyRegistry.json
+    cp out/VerifierKeyGen13.sol/Verifier.json ../oprf-test-utils/contracts/Verifier.13.json
+    cp out/VerifierKeyGen25.sol/Verifier.json ../oprf-test-utils/contracts/Verifier.25.json
+    cp out/BabyJubJub.sol/BabyJubJub.json ../oprf-test-utils/contracts/BabyJubJub.json
+    cp out/TestOprfKeyRegistry.sol/TestOprfKeyRegistry.json ../oprf-test-utils/contracts
+    cp out/ERC1967Proxy.sol/ERC1967Proxy.json ../oprf-test-utils/contracts
+
+[group('test')]
+contract-tests:
+    forge test
+
+[group('build')]
+show-contract-errors:
+    forge inspect src/OprfKeyRegistry.sol:OprfKeyRegistry errors
+    forge inspect src/VerifierKeyGen13.sol:Verifier errors
+    forge inspect src/VerifierKeyGen25.sol:Verifier errors
+
+[group('build')]
+show-contract-methods:
+    forge inspect src/OprfKeyRegistry.sol:OprfKeyRegistry methodIdentifiers
+
+[group('deploy')]
+deploy-oprf-key-registry-with-deps-dry-run *args:
+    forge script OprfKeyRegistryWithDeps.s.sol -vvvvv {{ args }}
+
+[group('deploy')]
+deploy-oprf-key-registry-with-deps *args:
+    forge script OprfKeyRegistryWithDeps.s.sol --broadcast --interactives 1 -vvvvv {{ args }} --rpc-url $RPC_URL --verify --verifier etherscan --etherscan-api-key $ETHERSCAN_API_KEY
+
+[group('deploy')]
+deploy-oprf-key-registry-dry-run *args:
+    forge script OprfKeyRegistry.s.sol -vvvvv {{ args }}
+
+[group('deploy')]
+deploy-oprf-key-registry *args:
+    forge script OprfKeyRegistry.s.sol --broadcast --interactives 1 -vvvvv {{ args }} --rpc-url $RPC_URL --verify --verifier etherscan --etherscan-api-key $ETHERSCAN_API_KEY
+
+[group('contract')]
+register-participants *args:
+    forge script RegisterParticipants.s.sol --broadcast --interactives 1 -vvvvv {{ args }} --rpc-url $RPC_URL
+
+[group('contract')]
+register-participants-dry-run *args:
+    forge script RegisterParticipants.s.sol -vvvvv {{ args }}
+
+[group('contract')]
+revoke-key-gen-admin-dry-run *args:
+    forge script RevokeKeyGenAdmin.s.sol -vvvvv {{ args }}
+
+[group('contract')]
+revoke-key-gen-admin *args:
+    forge script RevokeKeyGenAdmin.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
+
+[group('contract')]
+register-key-gen-admin-dry-run *args:
+    forge script RegisterKeyGenAdmin.s.sol -vvvvv {{ args }}
+
+[group('contract')]
+register-key-gen-admin *args:
+    forge script RegisterKeyGenAdmin.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
+
+[group('anvil')]
+deploy-oprf-key-registry-with-deps-anvil:
+    TACEO_ADMIN_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 THRESHOLD=2 NUM_PEERS=3 forge script OprfKeyRegistryWithDeps.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+[group('anvil')]
+deploy-oprf-key-registry-anvil:
+    TACEO_ADMIN_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 THRESHOLD=2 NUM_PEERS=3 forge script OprfKeyRegistry.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+[group('anvil')]
+register-participants-anvil:
+    PARTICIPANT_ADDRESSES=0x14dC79964da2C08b23698B3D3cc7Ca32193d9955,0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f,0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 forge script RegisterParticipants.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+[group('anvil')]
+revoke-key-gen-admin-anvil:
+    forge script RevokeKeyGenAdmin.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+[group('anvil')]
+register-key-gen-admin-anvil:
+    forge script RegisterKeyGenAdmin.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/script/deploy/OprfKeyRegistryImpl.s.sol
+++ b/script/deploy/OprfKeyRegistryImpl.s.sol
@@ -3,11 +3,9 @@ pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
 import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract DeployOprfKeyRegistryImplScript is Script {
     OprfKeyRegistry public oprfKeyRegistry;
-    ERC1967Proxy public proxy;
 
     function setUp() public {}
 

--- a/script/deploy/OprfKeyRegistryImpl.s.sol
+++ b/script/deploy/OprfKeyRegistryImpl.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Script, console} from "forge-std/Script.sol";
+import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract DeployOprfKeyRegistryImplScript is Script {
+    OprfKeyRegistry public oprfKeyRegistry;
+    ERC1967Proxy public proxy;
+
+    function setUp() public {}
+
+    function run() public {
+        vm.startBroadcast();
+
+        // Deploy implementation
+        OprfKeyRegistry implementation = new OprfKeyRegistry();
+
+        vm.stopBroadcast();
+        console.log("OprfKeyRegistry implementation deployed to:", address(implementation));
+    }
+}

--- a/script/deploy/UpgradeOprfKeyRegistry.s.sol
+++ b/script/deploy/UpgradeOprfKeyRegistry.s.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+
+contract UpgradeOprfKeyRegistryScript is Script {
+    OprfKeyRegistry public oprfKeyRegistryProxy;
+    address public oprfKeyRegistryNewImpl;
+
+    function setUp() public {
+        oprfKeyRegistryProxy = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+        oprfKeyRegistryNewImpl = vm.envAddress("OPRF_KEY_REGISTRY_NEW_IMPL");
+    }
+
+    function run() public {
+        console.log(
+            "Updating OPRF key-gen implementation from proxy",
+            address(oprfKeyRegistryProxy),
+            " to ",
+            oprfKeyRegistryNewImpl
+        );
+        vm.startBroadcast();
+        OprfKeyRegistry(address(oprfKeyRegistryProxy)).upgradeToAndCall(oprfKeyRegistryNewImpl, "");
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
- **build: added justfile**
- **build: added deploy and upgrade proxy scripts**
- **fix(build): update working directory in justfile**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> No on-chain contract logic changes, but the new upgrade script directly performs proxy upgrades and could cause misconfiguration or unintended upgrades if run with incorrect addresses or environment variables.
> 
> **Overview**
> Adds a new `justfile` that standardizes common Foundry workflows (build/test, ABI export, contract inspection) and provides one-command deploy/upgrade routines, including anvil presets.
> 
> Introduces two new Foundry scripts: `OprfKeyRegistryImpl.s.sol` to deploy a standalone `OprfKeyRegistry` implementation, and `UpgradeOprfKeyRegistry.s.sol` to upgrade an existing `OprfKeyRegistry` UUPS proxy via `upgradeToAndCall`, parameterized by `OPRF_KEY_REGISTRY_PROXY`/`OPRF_KEY_REGISTRY_NEW_IMPL` env vars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d67b582b5e80632f576260c3d58d1aee9117b9a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->