### PR TITLE
build: added two just commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -118,7 +118,7 @@ init-key-gen-dry-run *args:
 [group('contract')]
 [working-directory("script")]
 init-key-gen *args:
-    forge script InitKeyGen.s.sol -vvvvv --broadcast --interactives 1 {{ args }}--rpc-url $RPC_URL
+    forge script InitKeyGen.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
 
 [group('anvil')]
 [working-directory("script/deploy")]

--- a/justfile
+++ b/justfile
@@ -108,7 +108,17 @@ abort-key-gen-dry-run *args:
 [group('contract')]
 [working-directory("script")]
 abort-key-gen *args:
-    forge script AbortKeyGen.s.sol -vvvvv --broadcast --interactives 1 {{ args }}--rpc-url $RPC_URL
+    forge script AbortKeyGen.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
+
+[group('contract')]
+[working-directory("script")]
+init-key-gen-dry-run *args:
+    forge script InitKeyGen.s.sol -vvvvv {{ args }}
+
+[group('contract')]
+[working-directory("script")]
+init-key-gen *args:
+    forge script InitKeyGen.s.sol -vvvvv --broadcast --interactives 1 {{ args }}--rpc-url $RPC_URL
 
 [group('anvil')]
 [working-directory("script/deploy")]

--- a/justfile
+++ b/justfile
@@ -95,6 +95,21 @@ register-key-gen-admin-dry-run *args:
 register-key-gen-admin *args:
     forge script RegisterKeyGenAdmin.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
 
+[group('contract')]
+[working-directory("script")]
+print-information:
+    forge script PrintInformation.s.sol -vvvvv --rpc-url $RPC_URL
+
+[group('contract')]
+[working-directory("script")]
+abort-key-gen-dry-run *args:
+    forge script AbortKeyGen.s.sol -vvvvv {{ args }}
+
+[group('contract')]
+[working-directory("script")]
+abort-key-gen *args:
+    forge script AbortKeyGen.s.sol -vvvvv --broadcast --interactives 1 {{ args }}--rpc-url $RPC_URL
+
 [group('anvil')]
 [working-directory("script/deploy")]
 deploy-oprf-key-registry-with-deps-anvil:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build tooling-only change (new `just` targets) with no production code impact; main risk is running the new broadcast commands against the wrong RPC/network.
> 
> **Overview**
> Adds new `justfile` contract-operation commands to run Foundry scripts for key-gen lifecycle management: `print-information` (RPC-only), plus `init-key-gen`/`abort-key-gen` with matching `*-dry-run` variants and broadcasted execution via `$RPC_URL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 061278905d9ee2fff08c6e711ac5de218d2f974f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->