### PR TITLE
feat: added changeVerifierContract method

### DIFF
--- a/src/OprfKeyGen.sol
+++ b/src/OprfKeyGen.sol
@@ -87,6 +87,7 @@ library OprfKeyGen {
     event KeyGenAdminRevoked(address indexed admin);
     event KeyGenAdminRegistered(address indexed admin);
     event NotEnoughProducers(uint160 indexed oprfKeyId);
+    event VerifierContractChanged(address indexed oldContract, address newContract);
     // peer events
     event OprfPeerChanged(uint16 indexed partyId, address indexed oldPeer, address indexed newPeer);
 

--- a/src/OprfKeyGen.sol
+++ b/src/OprfKeyGen.sol
@@ -87,7 +87,7 @@ library OprfKeyGen {
     event KeyGenAdminRevoked(address indexed admin);
     event KeyGenAdminRegistered(address indexed admin);
     event NotEnoughProducers(uint160 indexed oprfKeyId);
-    event VerifierContractChanged(address indexed oldContract, address newContract);
+    event VerifierContractChanged(address indexed oldContract, address indexed newContract);
     // peer events
     event OprfPeerChanged(uint16 indexed partyId, address indexed oldPeer, address indexed newPeer);
 

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -27,6 +27,7 @@ interface IVerifierKeyGen25 {
 interface IOprfKeyRegistry {
     function abortKeyGen(uint160 oprfKeyId) external;
     function addKeyGenAdmin(address _keygenAdmin) external;
+    function changeVerifierContract(address newKeyGenVerifier) external;
     function deleteOprfPublicKey(uint160 oprfKeyId) external;
     function initKeyGen(uint160 oprfKeyId) external;
     function initReshare(uint160 oprfKeyId) external;

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -179,6 +179,18 @@ contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgrade
         }
     }
 
+    /// @notice Updates the key generation verifier contract.
+    ///
+    /// @dev This function does not verify whether the provided address is a valid
+    /// or trusted key generation verifier contract. Use with caution.
+    ///
+    /// @param newKeyGenVerifier The address of the new verifier contract
+    function changeVerifierContract(address newKeyGenVerifier) public virtual onlyProxy onlyInitialized onlyAdmin {
+        address oldKeyGenVerifier = keyGenVerifier;
+        keyGenVerifier = newKeyGenVerifier;
+        emit OprfKeyGen.VerifierContractChanged(oldKeyGenVerifier, newKeyGenVerifier);
+    }
+
     /// @notice Grants key-generation admin permissions to an address.
     ///
     /// @dev In the future, adding admins should require threshold authentication.

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -186,7 +186,7 @@ contract OprfKeyRegistry is IOprfKeyRegistry, Initializable, Ownable2StepUpgrade
     /// or trusted key generation verifier contract. Use with caution.
     ///
     /// @param newKeyGenVerifier The address of the new verifier contract
-    function changeVerifierContract(address newKeyGenVerifier) public virtual onlyProxy onlyInitialized onlyAdmin {
+    function changeVerifierContract(address newKeyGenVerifier) public virtual onlyProxy onlyInitialized onlyOwner {
         address oldKeyGenVerifier = keyGenVerifier;
         keyGenVerifier = newKeyGenVerifier;
         emit OprfKeyGen.VerifierContractChanged(oldKeyGenVerifier, newKeyGenVerifier);

--- a/test/OprfKeyRegistry.admin.t.sol
+++ b/test/OprfKeyRegistry.admin.t.sol
@@ -306,6 +306,22 @@ contract OprfKeyRegistryTest is Test {
         assertEq(0, vm.getRecordedLogs().length);
     }
 
+    function testChangeVerifierContract() public {
+        address newAddress = address(0x42);
+        vm.startPrank(taceoAdmin);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.VerifierContractChanged(address(verifierKeyGen), newAddress);
+        oprfKeyRegistry.changeVerifierContract(newAddress);
+        vm.stopPrank();
+    }
+
+    function testChangeVerifierContractNoAdmin() public {
+        vm.startPrank(alice);
+        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.OnlyAdmin.selector));
+        oprfKeyRegistry.changeVerifierContract(address(0x42));
+        vm.stopPrank();
+    }
+
     function testInitKeyGenResubmit() public {
         vm.prank(taceoAdmin);
         oprfKeyRegistry.initKeyGen(42);

--- a/test/OprfKeyRegistry.admin.t.sol
+++ b/test/OprfKeyRegistry.admin.t.sol
@@ -308,16 +308,14 @@ contract OprfKeyRegistryTest is Test {
 
     function testChangeVerifierContract() public {
         address newAddress = address(0x42);
-        vm.startPrank(taceoAdmin);
         vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.VerifierContractChanged(address(verifierKeyGen), newAddress);
         oprfKeyRegistry.changeVerifierContract(newAddress);
-        vm.stopPrank();
     }
 
-    function testChangeVerifierContractNoAdmin() public {
+    function testChangeVerifierContractNoOwner() public {
         vm.startPrank(alice);
-        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.OnlyAdmin.selector));
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
         oprfKeyRegistry.changeVerifierContract(address(0x42));
         vm.stopPrank();
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes who/what contract is used to verify Groth16 proofs; a misconfigured or malicious verifier address would directly impact key-gen security, though access is restricted to the owner.
> 
> **Overview**
> Adds an **owner-only** `changeVerifierContract` admin method on `OprfKeyRegistry` to update the `keyGenVerifier` address used for proof verification.
> 
> Introduces a new `OprfKeyGen.VerifierContractChanged(oldContract, newContract)` event, exposes the method via `IOprfKeyRegistry`, and adds tests to assert event emission and owner-only access control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bceccd14cb166f60972e6a32db2b178ed21060c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->