### PR TITLE
themis/add erc165

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,27 @@ This repository is part of the [TACEO:OPRF](https://github.com/TaceoLabs/oprf-se
 
 The contract provides functionality to initiate a new key generation protocol run, with the contract itself being used as a public message board for the parties' messages during the protocol.
 In addition it can also be used to trigger a key reshare procedure, which is similar to the key generation procedure, but refreshes the parties' key shares, keeping the underlying OPRF key the same.
+
+### Contract Versions
+
+#### OprfKeyRegistry (V1)
+
+The base upgradeable contract (UUPS proxy pattern) implementing the full MPC key generation and reshare protocol.
+
+#### OprfKeyRegistryV2
+
+Upgrades the registry with the following additions:
+
+- **ERC-165 support** — implements `supportsInterface` and declares the `IOprfKeyRegistryMpc` interface ID, enabling on-chain interface discovery.
+- **Domain tag** — a `bytes32 domainTag` derived from a restricted environment enum and a project identifier:
+  ```
+  keccak256("<env>-<projectDs>-TACEO:OPRF")
+  ```
+  The environment must be one of the `Environment` enum variants: `Test` → `"test"`, `Stage` → `"stage"`, `Prod` → `"prod"`.
+  Set once via `initializeV2` (called after upgrading the proxy) and optionally updated later via `updateDomainTag`.
+- **`contractCompCheck`** — a view function that asserts the contract matches a caller's expected interface ID, domain tag, peer count, and threshold, reverting with `ContractComp()` if any parameter mismatches. Intended for off-chain nodes to verify they are connected to the correct contract instance.
+
+### Upgrading to V2
+
+1. Deploy `OprfKeyRegistryV2` as a new implementation.
+2. Call `upgradeToAndCall` on the existing proxy, encoding `initializeV2(Environment, projectDs)` as the calldata so the domain tag is set atomically in the same transaction. Use the `ENVIRONMENT` env var (0=Test, 1=Stage, 2=Prod) with the upgrade just command.

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ default:
 [group('build')]
 export-contract-abi:
     forge build --silent && jq '.abi' out/OprfKeyRegistry.sol/OprfKeyRegistry.json > ../oprf-types/OprfKeyRegistry.json
+    jq '.abi' out/OprfKeyRegistryV2.sol/OprfKeyRegistryV2.json > ../oprf-types/OprfKeyRegistryV2.json
     cp out/VerifierKeyGen13.sol/Verifier.json ../oprf-test-utils/contracts/Verifier.13.json
     cp out/VerifierKeyGen25.sol/Verifier.json ../oprf-test-utils/contracts/Verifier.25.json
     cp out/BabyJubJub.sol/BabyJubJub.json ../oprf-test-utils/contracts/BabyJubJub.json
@@ -17,13 +18,13 @@ contract-tests:
 
 [group('build')]
 show-contract-errors:
-    forge inspect src/OprfKeyRegistry.sol:OprfKeyRegistry errors
+    forge inspect src/OprfKeyRegistryV2.sol:OprfKeyRegistryV2 errors
     forge inspect src/VerifierKeyGen13.sol:Verifier errors
     forge inspect src/VerifierKeyGen25.sol:Verifier errors
 
 [group('build')]
 show-contract-methods:
-    forge inspect src/OprfKeyRegistry.sol:OprfKeyRegistry methodIdentifiers
+    forge inspect src/OprfKeyRegistryV2.sol:OprfKeyRegistryV2 methodIdentifiers
 
 [group('deploy')]
 [working-directory("script/deploy")]
@@ -153,12 +154,12 @@ init-key-gen *args:
 [group('anvil')]
 [working-directory("script/deploy")]
 deploy-oprf-key-registry-with-deps-anvil:
-    TACEO_ADMIN_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 THRESHOLD=2 NUM_PEERS=3 forge script OprfKeyRegistryWithDeps.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+    TACEO_ADMIN_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 THRESHOLD=2 NUM_PEERS=3 ENVIRONMENT=test PROJECT_DS=local forge script OprfKeyRegistryWithDeps.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 [group('anvil')]
 [working-directory("script/deploy")]
 deploy-oprf-key-registry-anvil:
-    TACEO_ADMIN_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 THRESHOLD=2 NUM_PEERS=3 forge script OprfKeyRegistry.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+    TACEO_ADMIN_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 THRESHOLD=2 NUM_PEERS=3 ENVIRONMENT=test PROJECT_DS=local forge script OprfKeyRegistry.s.sol --broadcast --fork-url http://127.0.0.1:8545 -vvvvv --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 [group('anvil')]
 [working-directory("script")]

--- a/script/AbortKeyGen.s.sol
+++ b/script/AbortKeyGen.s.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 
 contract AbortOprfKeyGenScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {
-        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+        oprfKeyRegistry = OprfKeyRegistryV2(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
     }
 
     function run() public {

--- a/script/ChangeVerifierContract.s.sol
+++ b/script/ChangeVerifierContract.s.sol
@@ -2,16 +2,16 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 
 import {Verifier as Verifier13} from "../src/VerifierKeyGen13.sol";
 import {Verifier as Verifier25} from "../src/VerifierKeyGen25.sol";
 
 contract ChangeVerifierContractScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {
-        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+        oprfKeyRegistry = OprfKeyRegistryV2(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
     }
 
     function run() public {

--- a/script/DeleteOprfKey.s.sol
+++ b/script/DeleteOprfKey.s.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 
 contract DeleteOprfKeyScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {
-        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+        oprfKeyRegistry = OprfKeyRegistryV2(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
     }
 
     function run() public {

--- a/script/InitKeyGen.s.sol
+++ b/script/InitKeyGen.s.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 
 contract InitKeyGenScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {
-        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+        oprfKeyRegistry = OprfKeyRegistryV2(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
     }
 
     function run() external {

--- a/script/InitReshare.s.sol
+++ b/script/InitReshare.s.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 
 contract InitReshareScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {
-        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+        oprfKeyRegistry = OprfKeyRegistryV2(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
     }
 
     function run() external {

--- a/script/PrintInformation.s.sol
+++ b/script/PrintInformation.s.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 
 contract PrintInformationScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {
-        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+        oprfKeyRegistry = OprfKeyRegistryV2(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
     }
 
     function run() external {
@@ -18,11 +18,13 @@ contract PrintInformationScript is Script {
         address keyGenVerifier = oprfKeyRegistry.keyGenVerifier();
         uint256 threshold = oprfKeyRegistry.threshold();
         uint256 numPeers = oprfKeyRegistry.numPeers();
+        bytes32 domainTag = oprfKeyRegistry.domainTag();
         console.log("isContractReady:", isContractReady);
         console.log("amountAdmins:", amountAdmins);
         console.log("keyGenVerifier:", keyGenVerifier);
         console.log("threshold:", threshold);
         console.log("numPeers:", numPeers);
+        console.logBytes32(domainTag);
         if (isContractReady) {
             console.log("PEERS:");
             for (uint256 i = 0; i < numPeers; ++i) {

--- a/script/RegisterKeyGenAdmin.s.sol
+++ b/script/RegisterKeyGenAdmin.s.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 
 contract RevokeKeyGenAdminScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {
-        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+        oprfKeyRegistry = OprfKeyRegistryV2(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
     }
 
     function run() public {

--- a/script/RegisterParticipants.s.sol
+++ b/script/RegisterParticipants.s.sol
@@ -2,16 +2,16 @@
 pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 
 contract RegisterParticipantScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {
         address oprfKeyRegistryAddress = vm.envAddress("OPRF_KEY_REGISTRY_PROXY");
         console.log("register Participants for OprfKeyRegistry Proxy contract at:", oprfKeyRegistryAddress);
 
-        oprfKeyRegistry = OprfKeyRegistry(oprfKeyRegistryAddress);
+        oprfKeyRegistry = OprfKeyRegistryV2(oprfKeyRegistryAddress);
     }
 
     function run() public {

--- a/script/RevokeKeyGenAdmin.s.sol
+++ b/script/RevokeKeyGenAdmin.s.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 
 contract RevokeKeyGenAdminScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {
-        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+        oprfKeyRegistry = OprfKeyRegistryV2(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
     }
 
     function run() public {

--- a/script/deploy/OprfKeyRegistry.s.sol
+++ b/script/deploy/OprfKeyRegistry.s.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
 import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../../src/OprfKeyRegistryV2.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract DeployOprfKeyRegistryScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
     ERC1967Proxy public proxy;
 
     function setUp() public {}
@@ -19,24 +20,30 @@ contract DeployOprfKeyRegistryScript is Script {
         address keyGenVerifierAddress = vm.envAddress("KEY_GEN_VERIFIER_ADDRESS");
         uint256 threshold = vm.envUint("THRESHOLD");
         uint256 numPeers = vm.envUint("NUM_PEERS");
+        string memory environmentTag = vm.envString("ENVIRONMENT");
+        string memory projectDs = vm.envString("PROJECT_DS");
 
         console.log("using TACEO address:", taceoAdminAddress);
         console.log("using key-gen verifier address:", keyGenVerifierAddress);
         console.log("using threshold:", threshold);
         console.log("using numPeers:", numPeers);
+        console.log("using environment:", environmentTag);
+        console.log("using projectDs:", projectDs);
 
-        // Deploy implementation
-        OprfKeyRegistry implementation = new OprfKeyRegistry();
-        // Encode initializer call
+        // Deploy V2 implementation
+        OprfKeyRegistryV2 implementation = new OprfKeyRegistryV2();
+        // Encode initializer call (uses V1 initialize, inherited by V2)
         bytes memory initData = abi.encodeWithSelector(
             OprfKeyRegistry.initialize.selector, owner, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);
-        oprfKeyRegistry = OprfKeyRegistry(address(proxy));
+        oprfKeyRegistry = OprfKeyRegistryV2(address(proxy));
+        // Initialize V2-specific state
+        oprfKeyRegistry.initializeV2(environmentTag, projectDs);
 
         vm.stopBroadcast();
-        console.log("OprfKeyRegistry implementation deployed to:", address(implementation));
-        console.log("OprfKeyRegistry proxy deployed to:", address(oprfKeyRegistry));
+        console.log("OprfKeyRegistryV2 implementation deployed to:", address(implementation));
+        console.log("OprfKeyRegistryV2 proxy deployed to:", address(oprfKeyRegistry));
     }
 }

--- a/script/deploy/OprfKeyRegistryImpl.s.sol
+++ b/script/deploy/OprfKeyRegistryImpl.s.sol
@@ -2,20 +2,20 @@
 pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../../src/OprfKeyRegistryV2.sol";
 
 contract DeployOprfKeyRegistryImplScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {}
 
     function run() public {
         vm.startBroadcast();
 
-        // Deploy implementation
-        OprfKeyRegistry implementation = new OprfKeyRegistry();
+        // Deploy V2 implementation
+        OprfKeyRegistryV2 implementation = new OprfKeyRegistryV2();
 
         vm.stopBroadcast();
-        console.log("OprfKeyRegistry implementation deployed to:", address(implementation));
+        console.log("OprfKeyRegistryV2 implementation deployed to:", address(implementation));
     }
 }

--- a/script/deploy/OprfKeyRegistryWithDeps.s.sol
+++ b/script/deploy/OprfKeyRegistryWithDeps.s.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
 import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../../src/OprfKeyRegistryV2.sol";
 import {Verifier as VerifierKeyGen13} from "../../src/VerifierKeyGen13.sol";
 import {Verifier as VerifierKeyGen25} from "../../src/VerifierKeyGen25.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract DeployOprfKeyRegistryWithDepsScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
     ERC1967Proxy public proxy;
 
     function setUp() public {}
@@ -34,19 +35,23 @@ contract DeployOprfKeyRegistryWithDepsScript is Script {
         address taceoAdminAddress = vm.envAddress("TACEO_ADMIN_ADDRESS");
         uint256 threshold = vm.envUint("THRESHOLD");
         uint256 numPeers = vm.envUint("NUM_PEERS");
+        string memory environmentTag = vm.envString("ENVIRONMENT");
+        string memory projectDs = vm.envString("PROJECT_DS");
 
         address keyGenVerifierAddress = deployGroth16VerifierKeyGen(threshold, numPeers);
-        // Deploy implementation
-        OprfKeyRegistry implementation = new OprfKeyRegistry();
-        // Encode initializer call
+        // Deploy V2 implementation
+        OprfKeyRegistryV2 implementation = new OprfKeyRegistryV2();
+        // Encode initializer call (uses V1 initialize, inherited by V2)
         bytes memory initData = abi.encodeWithSelector(
             OprfKeyRegistry.initialize.selector, owner, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);
-        oprfKeyRegistry = OprfKeyRegistry(address(proxy));
+        oprfKeyRegistry = OprfKeyRegistryV2(address(proxy));
+        // Initialize V2-specific state
+        oprfKeyRegistry.initializeV2(environmentTag, projectDs);
 
-        console.log("OprfKeyRegistry implementation deployed to:", address(implementation));
-        console.log("OprfKeyRegistry proxy deployed to:", address(oprfKeyRegistry));
+        console.log("OprfKeyRegistryV2 implementation deployed to:", address(implementation));
+        console.log("OprfKeyRegistryV2 proxy deployed to:", address(oprfKeyRegistry));
     }
 }

--- a/script/deploy/UpgradeOprfKeyRegistry.s.sol
+++ b/script/deploy/UpgradeOprfKeyRegistry.s.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
 import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../../src/OprfKeyRegistryV2.sol";
 
 contract UpgradeOprfKeyRegistryScript is Script {
     OprfKeyRegistry public oprfKeyRegistryProxy;
@@ -14,14 +15,23 @@ contract UpgradeOprfKeyRegistryScript is Script {
     }
 
     function run() public {
+        string memory environmentTag = vm.envString("ENVIRONMENT");
+        string memory projectDs = vm.envString("PROJECT_DS");
+
         console.log(
             "Updating OPRF key-gen implementation from proxy",
             address(oprfKeyRegistryProxy),
             " to ",
             oprfKeyRegistryNewImpl
         );
+        console.log("Initializing V2 with environment:", environmentTag);
+        console.log("Initializing V2 with projectDs:", projectDs);
+
+        bytes memory initV2Data =
+            abi.encodeWithSelector(OprfKeyRegistryV2.initializeV2.selector, environmentTag, projectDs);
+
         vm.startBroadcast();
-        OprfKeyRegistry(address(oprfKeyRegistryProxy)).upgradeToAndCall(oprfKeyRegistryNewImpl, "");
+        OprfKeyRegistry(address(oprfKeyRegistryProxy)).upgradeToAndCall(oprfKeyRegistryNewImpl, initV2Data);
         vm.stopBroadcast();
     }
 }

--- a/script/test/TestSetup.s.sol
+++ b/script/test/TestSetup.s.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
 import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../../src/OprfKeyRegistryV2.sol";
 import {Verifier as VerifierKeyGen13} from "../../src/VerifierKeyGen13.sol";
 import {Verifier as VerifierKeyGen25} from "../../src/VerifierKeyGen25.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract TestSetupScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
     ERC1967Proxy public proxy;
 
     function setUp() public {}
@@ -35,21 +36,25 @@ contract TestSetupScript is Script {
         address keyGenVerifierAddress = deployGroth16VerifierKeyGen(threshold, numPeers);
         address taceoAdminAddress = vm.envAddress("TACEO_ADMIN_ADDRESS");
         address owner = msg.sender;
+        string memory environmentTag = vm.envString("ENVIRONMENT");
+        string memory projectDs = vm.envString("PROJECT_DS");
 
         address[] memory participants = vm.envAddress("PARTICIPANT_ADDRESSES", ",");
         for (uint256 i = 0; i < participants.length; i++) {
             console.log("Registering participant address:", participants[i]);
         }
 
-        // Deploy implementation
-        OprfKeyRegistry implementation = new OprfKeyRegistry();
-        // Encode initializer call
+        // Deploy V2 implementation
+        OprfKeyRegistryV2 implementation = new OprfKeyRegistryV2();
+        // Encode initializer call (uses V1 initialize, inherited by V2)
         bytes memory initData = abi.encodeWithSelector(
             OprfKeyRegistry.initialize.selector, owner, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);
-        oprfKeyRegistry = OprfKeyRegistry(address(proxy));
+        oprfKeyRegistry = OprfKeyRegistryV2(address(proxy));
+        // Initialize V2-specific state
+        oprfKeyRegistry.initializeV2(environmentTag, projectDs);
 
         oprfKeyRegistry.registerOprfPeers(participants);
 
@@ -57,6 +62,6 @@ contract TestSetupScript is Script {
         assert(oprfKeyRegistry.isContractReady());
         vm.stopBroadcast();
 
-        console.log("OprfKeyRegistry deployed to:", address(oprfKeyRegistry));
+        console.log("OprfKeyRegistryV2 deployed to:", address(oprfKeyRegistry));
     }
 }

--- a/src/OprfKeyRegistry.sol
+++ b/src/OprfKeyRegistry.sol
@@ -34,6 +34,25 @@ interface IOprfKeyRegistry {
     function revokeKeyGenAdmin(address _keygenAdmin) external;
 }
 
+interface IOprfKeyRegistryMpc {
+    function addRound1KeyGenContribution(uint160 oprfKeyId, OprfKeyGen.Round1Contribution calldata data) external;
+    function addRound1ReshareContribution(uint160 oprfKeyId, OprfKeyGen.Round1Contribution calldata data) external;
+    function addRound2Contribution(uint160 oprfKeyId, OprfKeyGen.Round2Contribution calldata data) external;
+    function addRound3Contribution(uint160 oprfKeyId) external;
+    function getPartyIdForParticipant(address participant) external view returns (uint256);
+    function loadPeerPublicKeysForProducers(uint160 oprfKeyId) external view returns (BabyJubJub.Affine[] memory);
+    function loadPeerPublicKeysForConsumers(uint160 oprfKeyId) external view returns (BabyJubJub.Affine[] memory);
+    function checkIsParticipantAndReturnRound2Ciphers(uint160 oprfKeyId)
+        external
+        view
+        returns (OprfKeyGen.SecretGenCiphertext[] memory);
+    function getOprfPublicKey(uint160 oprfKeyId) external view returns (BabyJubJub.Affine memory);
+    function getOprfPublicKeyAndEpoch(uint160 oprfKeyId)
+        external
+        view
+        returns (OprfKeyGen.RegisteredOprfPublicKey memory);
+}
+
 /// @dev This contract does not include a storage gap. Upgrades are expected to be
 /// implemented via inheritance from this contract, which preserves the storage
 /// layout. No guarantees are provided for upgrade patterns that do not inherit

--- a/src/OprfKeyRegistryV2.sol
+++ b/src/OprfKeyRegistryV2.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IOprfKeyRegistry, IOprfKeyRegistryMpc, OprfKeyRegistry} from "./OprfKeyRegistry.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+string constant OPRF_TAG = "TACEO:OPRF";
+
+/// @custom:oz-upgrades-from OprfKeyRegistry
+/// @title Upgradeable OPRF Key Registry V2
+/// @notice Adds upgrade-safe domain tag initialization for proxies
+contract OprfKeyRegistryV2 is OprfKeyRegistry, ERC165 {
+    /// @notice The domain tag identifying environment and project context
+    /// @dev Mutable to allow proxy initialization
+    bytes32 public domainTag;
+
+    /// @notice Error thrown when a contract does not match expected parameters
+    error ContractComp();
+
+    /// @notice Emitted whenever the domain tag is updated
+    /// @param oldDomainTag The previous domain tag
+    /// @param newDomainTag The new domain tag
+    event DomainTagUpdated(bytes32 indexed oldDomainTag, bytes32 indexed newDomainTag);
+
+    /// @notice Initializes V2-specific state for upgradeable proxies
+    /// @param _environmentTag The deployment environment
+    /// @param _projectDs The project identifier
+    /// @dev Must be called **once** after upgrading to V2
+    function initializeV2(string calldata _environmentTag, string calldata _projectDs)
+        public
+        reinitializer(2)
+        onlyOwner
+    {
+        _updateDomainTag(_environmentTag, _projectDs);
+    }
+
+    /// @notice Optionally allows manual update of domain tag
+    /// @param _environmentTag The deployment environment
+    /// @param _projectDs The project identifier
+    /// @dev Only callable by owner via proxy
+    function updateDomainTag(string calldata _environmentTag, string calldata _projectDs)
+        public
+        virtual
+        onlyOwner
+        onlyProxy
+    {
+        _updateDomainTag(_environmentTag, _projectDs);
+    }
+
+    /// @notice Checks whether the contract implements a given interface
+    /// @param interfaceId The ERC-165 interface ID to check
+    /// @return True if the contract supports the interface, false otherwise
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IOprfKeyRegistryMpc).interfaceId || interfaceId == type(IOprfKeyRegistry).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
+    /// @notice Validates that the contract matches expected interface and configuration
+    /// @param _interfaceId The expected ERC-165 interface ID
+    /// @param _domainTag The expected domain tag
+    /// @param _numPeers The expected number of MPC peers
+    /// @param _threshold The expected MPC threshold
+    function contractCompCheck(bytes4 _interfaceId, bytes32 _domainTag, uint16 _numPeers, uint16 _threshold)
+        public
+        view
+        virtual
+    {
+        if (
+            !supportsInterface(_interfaceId) || domainTag != _domainTag || numPeers != _numPeers
+                || threshold != _threshold
+        ) {
+            revert ContractComp();
+        }
+    }
+
+    function _updateDomainTag(string calldata _environmentTag, string calldata _projectDs) internal virtual {
+        bytes32 oldTag = domainTag;
+        domainTag = keccak256(bytes(string.concat(_environmentTag, "-", _projectDs, "-", OPRF_TAG)));
+        emit DomainTagUpdated(oldTag, domainTag);
+    }
+}

--- a/test/OprfKeyRegistryV2.t.sol
+++ b/test/OprfKeyRegistryV2.t.sol
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {BabyJubJub} from "@taceo/babyjubjub/BabyJubJub.sol";
+import {Contributions} from "./Contributions.t.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IOprfKeyRegistryMpc, OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Test} from "forge-std/Test.sol";
+import {Verifier as VerifierKeyGen13} from "../src/VerifierKeyGen13.sol";
+
+contract OprfKeyRegistryV2Test is Test {
+    using BabyJubJub for BabyJubJub.Affine;
+
+    uint16 public constant THRESHOLD = 2;
+    uint16 public constant MAX_PEERS = 3;
+
+    string constant ENV = "prod";
+    string constant PROJECT_DS = "myproject";
+
+    OprfKeyRegistry public oprfKeyRegistry;
+    VerifierKeyGen13 public verifierKeyGen;
+    ERC1967Proxy public proxy;
+
+    address alice = address(0x1);
+    address bob = address(0x2);
+    address carol = address(0x3);
+    address taceoAdmin = address(0x4);
+    address notOwner = address(0x5);
+    address initOwner = 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496; // default forge test contract address
+
+    function setUp() public {
+        verifierKeyGen = new VerifierKeyGen13();
+        OprfKeyRegistry implementation = new OprfKeyRegistry();
+        bytes memory initData = abi.encodeWithSelector(
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+        );
+        proxy = new ERC1967Proxy(address(implementation), initData);
+        oprfKeyRegistry = OprfKeyRegistry(address(proxy));
+
+        address[] memory peerAddresses = new address[](3);
+        peerAddresses[0] = alice;
+        peerAddresses[1] = bob;
+        peerAddresses[2] = carol;
+        oprfKeyRegistry.registerOprfPeers(peerAddresses);
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    /// @dev Upgrades the proxy to a fresh V2 implementation (no initialization).
+    function _upgradeToV2() internal returns (OprfKeyRegistryV2) {
+        OprfKeyRegistryV2 implementationV2 = new OprfKeyRegistryV2();
+        OprfKeyRegistry(address(proxy)).upgradeToAndCall(address(implementationV2), "");
+        return OprfKeyRegistryV2(address(proxy));
+    }
+
+    /// @dev Upgrades the proxy to V2 and calls initializeV2 atomically.
+    function _upgradeAndInitV2() internal returns (OprfKeyRegistryV2) {
+        OprfKeyRegistryV2 implementationV2 = new OprfKeyRegistryV2();
+        bytes memory initV2Data = abi.encodeWithSelector(OprfKeyRegistryV2.initializeV2.selector, ENV, PROJECT_DS);
+        OprfKeyRegistry(address(proxy)).upgradeToAndCall(address(implementationV2), initV2Data);
+        return OprfKeyRegistryV2(address(proxy));
+    }
+
+    function _expectedDomainTag(string memory envStr, string memory project) internal pure returns (bytes32) {
+        return keccak256(bytes(string.concat(envStr, "-", project, "-TACEO:OPRF")));
+    }
+
+    function _runFullKeyGen(OprfKeyRegistry registry, uint160 oprfKeyId) internal {
+        vm.prank(taceoAdmin);
+        registry.initKeyGen(oprfKeyId);
+        vm.stopPrank();
+
+        vm.prank(bob);
+        registry.addRound1KeyGenContribution(oprfKeyId, Contributions.bobKeyGenRound1Contribution());
+        vm.stopPrank();
+
+        vm.prank(alice);
+        registry.addRound1KeyGenContribution(oprfKeyId, Contributions.aliceKeyGenRound1Contribution());
+        vm.stopPrank();
+
+        vm.prank(carol);
+        registry.addRound1KeyGenContribution(oprfKeyId, Contributions.carolKeyGenRound1Contribution());
+        vm.stopPrank();
+
+        vm.prank(bob);
+        registry.addRound2Contribution(oprfKeyId, Contributions.bobKeyGenRound2Contribution());
+        vm.stopPrank();
+
+        vm.prank(alice);
+        registry.addRound2Contribution(oprfKeyId, Contributions.aliceKeyGenRound2Contribution());
+        vm.stopPrank();
+
+        vm.prank(carol);
+        registry.addRound2Contribution(oprfKeyId, Contributions.carolKeyGenRound2Contribution());
+        vm.stopPrank();
+
+        vm.prank(alice);
+        registry.addRound3Contribution(oprfKeyId);
+        vm.stopPrank();
+
+        vm.prank(bob);
+        registry.addRound3Contribution(oprfKeyId);
+        vm.stopPrank();
+
+        vm.prank(carol);
+        registry.addRound3Contribution(oprfKeyId);
+        vm.stopPrank();
+    }
+
+    // ============================================================
+    // Upgrade
+    // ============================================================
+
+    function testUpgradeToV2PreservesStorage() public {
+        _runFullKeyGen(oprfKeyRegistry, 42);
+        BabyJubJub.Affine memory keyBefore = oprfKeyRegistry.getOprfPublicKey(42);
+
+        OprfKeyRegistryV2 v2 = _upgradeToV2();
+
+        BabyJubJub.Affine memory keyAfter = v2.getOprfPublicKey(42);
+        assertEq(keyAfter.x, keyBefore.x);
+        assertEq(keyAfter.y, keyBefore.y);
+        assertEq(keyAfter.x, Contributions.SHOULD_OPRF_PUBLIC_KEY_X);
+        assertEq(keyAfter.y, Contributions.SHOULD_OPRF_PUBLIC_KEY_Y);
+    }
+
+    function testUpgradeToV2DomainTagIsZeroUntilInitialized() public {
+        OprfKeyRegistryV2 v2 = _upgradeToV2();
+        assertEq(v2.domainTag(), bytes32(0));
+    }
+
+    // ============================================================
+    // initializeV2
+    // ============================================================
+
+    function testInitializeV2SetsDomainTag() public {
+        OprfKeyRegistryV2 v2 = _upgradeToV2();
+        bytes32 expected = _expectedDomainTag(ENV, PROJECT_DS);
+
+        vm.expectEmit(true, true, false, false);
+        emit OprfKeyRegistryV2.DomainTagUpdated(bytes32(0), expected);
+        v2.initializeV2(ENV, PROJECT_DS);
+
+        assertEq(v2.domainTag(), expected);
+    }
+
+    function testInitializeV2RevertsOnSecondCall() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        v2.initializeV2(ENV, PROJECT_DS);
+    }
+
+    function testInitializeV2RevertsForNonOwner() public {
+        OprfKeyRegistryV2 v2 = _upgradeToV2();
+
+        vm.prank(notOwner);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, notOwner));
+        v2.initializeV2(ENV, PROJECT_DS);
+        vm.stopPrank();
+    }
+
+    function testUpgradeAndInitializeAtomically() public {
+        bytes32 expected = _expectedDomainTag(ENV, PROJECT_DS);
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+        assertEq(v2.domainTag(), expected);
+    }
+
+    // ============================================================
+    // updateDomainTag
+    // ============================================================
+
+    function testUpdateDomainTag() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+        bytes32 oldTag = v2.domainTag();
+        bytes32 newExpected = _expectedDomainTag("stage", "otherproject");
+
+        vm.expectEmit(true, true, false, false);
+        emit OprfKeyRegistryV2.DomainTagUpdated(oldTag, newExpected);
+        v2.updateDomainTag("stage", "otherproject");
+
+        assertEq(v2.domainTag(), newExpected);
+    }
+
+    function testUpdateDomainTagRevertsForNonOwner() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+
+        vm.prank(notOwner);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, notOwner));
+        v2.updateDomainTag("stage", "otherproject");
+        vm.stopPrank();
+    }
+
+    // ============================================================
+    // Domain tag computation per environment
+    // ============================================================
+
+    function testDomainTagComputationTest() public {
+        OprfKeyRegistryV2 v2 = _upgradeToV2();
+        v2.initializeV2("test", "taceo");
+        assertEq(v2.domainTag(), keccak256(bytes("test-taceo-TACEO:OPRF")));
+    }
+
+    function testDomainTagComputationStage() public {
+        OprfKeyRegistryV2 v2 = _upgradeToV2();
+        v2.initializeV2("stage", "taceo");
+        assertEq(v2.domainTag(), keccak256(bytes("stage-taceo-TACEO:OPRF")));
+    }
+
+    function testDomainTagComputationProd() public {
+        OprfKeyRegistryV2 v2 = _upgradeToV2();
+        v2.initializeV2("prod", "taceo");
+        assertEq(v2.domainTag(), keccak256(bytes("prod-taceo-TACEO:OPRF")));
+    }
+
+    // ============================================================
+    // supportsInterface (ERC-165)
+    // ============================================================
+
+    function testSupportsIOprfKeyRegistryMpc() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+        assertTrue(v2.supportsInterface(type(IOprfKeyRegistryMpc).interfaceId));
+    }
+
+    function testSupportsIERC165() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+        assertTrue(v2.supportsInterface(type(IERC165).interfaceId));
+    }
+
+    function testDoesNotSupportUnknownInterface() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+        assertFalse(v2.supportsInterface(bytes4(0xdeadbeef)));
+    }
+
+    // ============================================================
+    // contractCompCheck
+    // ============================================================
+
+    function testContractCompCheckSuccess() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+        bytes32 tag = v2.domainTag();
+        // should not revert
+        v2.contractCompCheck(type(IOprfKeyRegistryMpc).interfaceId, tag, MAX_PEERS, THRESHOLD);
+    }
+
+    function testContractCompCheckWrongInterface() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+        bytes32 tag = v2.domainTag();
+
+        vm.expectRevert(OprfKeyRegistryV2.ContractComp.selector);
+        v2.contractCompCheck(bytes4(0xdeadbeef), tag, MAX_PEERS, THRESHOLD);
+    }
+
+    function testContractCompCheckWrongDomainTag() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+
+        vm.expectRevert(OprfKeyRegistryV2.ContractComp.selector);
+        v2.contractCompCheck(type(IOprfKeyRegistryMpc).interfaceId, bytes32(uint256(1)), MAX_PEERS, THRESHOLD);
+    }
+
+    function testContractCompCheckWrongNumPeers() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+        bytes32 tag = v2.domainTag();
+
+        vm.expectRevert(OprfKeyRegistryV2.ContractComp.selector);
+        v2.contractCompCheck(type(IOprfKeyRegistryMpc).interfaceId, tag, MAX_PEERS + 1, THRESHOLD);
+    }
+
+    function testContractCompCheckWrongThreshold() public {
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+        bytes32 tag = v2.domainTag();
+
+        vm.expectRevert(OprfKeyRegistryV2.ContractComp.selector);
+        v2.contractCompCheck(type(IOprfKeyRegistryMpc).interfaceId, tag, MAX_PEERS, THRESHOLD + 1);
+    }
+
+    // ============================================================
+    // Full upgrade flow with key generation
+    // ============================================================
+
+    function testFullUpgradeFlowWithKeyGen() public {
+        // Complete a key gen on V1
+        _runFullKeyGen(oprfKeyRegistry, 42);
+
+        // Upgrade to V2 and initialize domain tag atomically
+        OprfKeyRegistryV2 v2 = _upgradeAndInitV2();
+
+        // V1 key is preserved after upgrade
+        BabyJubJub.Affine memory key = v2.getOprfPublicKey(42);
+        assertEq(key.x, Contributions.SHOULD_OPRF_PUBLIC_KEY_X);
+        assertEq(key.y, Contributions.SHOULD_OPRF_PUBLIC_KEY_Y);
+
+        // New key gen works on the upgraded V2 contract
+        _runFullKeyGen(OprfKeyRegistry(address(proxy)), 43);
+        BabyJubJub.Affine memory newKey = v2.getOprfPublicKey(43);
+        assertEq(newKey.x, Contributions.SHOULD_OPRF_PUBLIC_KEY_X);
+        assertEq(newKey.y, Contributions.SHOULD_OPRF_PUBLIC_KEY_Y);
+
+        // contractCompCheck passes with the correct parameters
+        bytes32 tag = v2.domainTag();
+        v2.contractCompCheck(type(IOprfKeyRegistryMpc).interfaceId, tag, MAX_PEERS, THRESHOLD);
+    }
+}


### PR DESCRIPTION
- **feat: add version2 for oprf-key-registry**
- **test: added tests for upgrade and added readme section**
- **refactor: updated v2 scripts and tests**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new upgradeable contract version and changes upgrade/deploy scripts to run V2 initialization (`upgradeToAndCall` with `initializeV2`), which could misconfigure proxies if env vars are wrong. Core MPC/keygen logic is inherited unchanged, and added tests cover storage preservation and the new V2 behaviors.
> 
> **Overview**
> Adds `OprfKeyRegistryV2` as an upgrade-safe extension of `OprfKeyRegistry` that implements **ERC-165 interface discovery** (advertising `IOprfKeyRegistryMpc`/`IOprfKeyRegistry`) and introduces a configurable `domainTag` (`keccak256("<env>-<projectDs>-TACEO:OPRF")`) with `initializeV2`/`updateDomainTag` plus a `contractCompCheck` guard for off-chain contract/config verification.
> 
> Updates deploy/upgrade and operational scripts to target `OprfKeyRegistryV2`, require `ENVIRONMENT` + `PROJECT_DS`, and initialize V2 state during deployment and via `upgradeToAndCall`; adds a comprehensive V2 test suite validating upgrade storage preservation, domain-tag initialization rules, ERC-165 support, and `contractCompCheck`, and documents the V1/V2 split and upgrade steps in `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1d2e87651ae7df6e92fad5436ec12c4ad2a503d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->