### PR TITLE
feat: allow nodes to report key gen stuck

### DIFF
--- a/src/UnreleasedOprfKeyRegistryV2.sol
+++ b/src/UnreleasedOprfKeyRegistryV2.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {OprfKeyGen} from "./OprfKeyGen.sol";
+import {OprfKeyRegistry} from "./OprfKeyRegistry.sol";
+
+/// @title Unreleased OPRF Key Registry V2
+/// @notice Next unreleased version of `OprfKeyRegistry` intended for proxy upgrades.
+/// @dev Change list for this version:
+/// - Adds `reportKeyGenStuck(uint160)` so registered nodes can report key-generation/reshare processes as stuck.
+/// @custom:oz-upgrades-from OprfKeyRegistry
+contract UnreleasedOprfKeyRegistryV2 is OprfKeyRegistry {
+    event KeyGenStuckReported(uint160 indexed oprfKeyId, address indexed reporter, OprfKeyGen.Round previousRound);
+
+    /// @notice Allows a registered OPRF node to report an active key-gen/reshare is stuck.
+    /// @param oprfKeyId The unique identifier for the OPRF key process.
+    function reportKeyGenStuck(uint160 oprfKeyId) public virtual onlyProxy isReady {
+        if (!addressToPeer[msg.sender].isParticipant) revert NotAParticipant();
+
+        OprfKeyGen.OprfKeyGenState storage st = runningKeyGens[oprfKeyId];
+        OprfKeyGen.Round currentRound = st.currentRound;
+
+        if (currentRound == OprfKeyGen.Round.NOT_STARTED) revert UnknownId(oprfKeyId);
+        if (currentRound == OprfKeyGen.Round.DELETED) revert DeletedId(oprfKeyId);
+        if (
+            currentRound != OprfKeyGen.Round.ONE && currentRound != OprfKeyGen.Round.TWO
+                && currentRound != OprfKeyGen.Round.THREE
+        ) {
+            revert WrongRound(currentRound);
+        }
+
+        st.currentRound = OprfKeyGen.Round.STUCK;
+        emit KeyGenStuckReported(oprfKeyId, msg.sender, currentRound);
+    }
+}

--- a/test/OprfKeyRegistryUpgrade.t.sol
+++ b/test/OprfKeyRegistryUpgrade.t.sol
@@ -6,34 +6,11 @@ import {Contributions} from "./Contributions.t.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {OprfKeyGen} from "../src/OprfKeyGen.sol";
 import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {UnreleasedOprfKeyRegistryV2} from "../src/UnreleasedOprfKeyRegistryV2.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {Test} from "forge-std/Test.sol";
 import {Verifier as VerifierKeyGen13} from "../src/VerifierKeyGen13.sol";
-
-/**
- *
- *
- * @title OprfKeyRegistryV2Mock
- *
- *
- * @notice Mock V2 implementation for testing upgrades
- *
- *
- */
-contract OprfKeyRegistryV2Mock is OprfKeyRegistry {
-    // Add a new state variable to test storage layout preservation
-
-    uint256 public newFeature;
-
-    function version() public pure returns (string memory) {
-        return "V2";
-    }
-
-    function setNewFeature(uint256 _value) public {
-        newFeature = _value;
-    }
-}
 
 contract OprfKeyRegistryUpgradeTest is Test {
     using BabyJubJub for BabyJubJub.Affine;
@@ -163,11 +140,11 @@ contract OprfKeyRegistryUpgradeTest is Test {
         assertEq(oprfKey.y, Contributions.SHOULD_OPRF_PUBLIC_KEY_Y);
 
         // Now perform upgrade
-        OprfKeyRegistryV2Mock implementationV2 = new OprfKeyRegistryV2Mock();
+        UnreleasedOprfKeyRegistryV2 implementationV2 = new UnreleasedOprfKeyRegistryV2();
         // upgrade as owner
         OprfKeyRegistry(address(proxy)).upgradeToAndCall(address(implementationV2), "");
         // Wrap proxy with V2 interface
-        OprfKeyRegistryV2Mock oprfKeyRegistryV2 = OprfKeyRegistryV2Mock(address(proxy));
+        UnreleasedOprfKeyRegistryV2 oprfKeyRegistryV2 = UnreleasedOprfKeyRegistryV2(address(proxy));
 
         // Verify storage was preserved
         BabyJubJub.Affine memory oprfKeyV2 = oprfKeyRegistryV2.getOprfPublicKey(oprfKeyId);
@@ -175,12 +152,26 @@ contract OprfKeyRegistryUpgradeTest is Test {
         assertEq(oprfKeyV2.y, Contributions.SHOULD_OPRF_PUBLIC_KEY_Y);
 
         // Verify new functionality works
-        assertEq(oprfKeyRegistryV2.version(), "V2");
-        oprfKeyRegistryV2.setNewFeature(42);
-        assertEq(oprfKeyRegistryV2.newFeature(), 42);
+        uint160 stuckOprfKeyId = 43;
+        vm.prank(taceoAdmin);
+        vm.expectEmit(true, true, true, true);
+        emit OprfKeyGen.SecretGenRound1(stuckOprfKeyId, THRESHOLD);
+        oprfKeyRegistryV2.initKeyGen(stuckOprfKeyId);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, true, true);
+        emit UnreleasedOprfKeyRegistryV2.KeyGenStuckReported(stuckOprfKeyId, alice, OprfKeyGen.Round.ONE);
+        oprfKeyRegistryV2.reportKeyGenStuck(stuckOprfKeyId);
+        vm.stopPrank();
+
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.WrongRound.selector, 4));
+        oprfKeyRegistryV2.addRound1KeyGenContribution(stuckOprfKeyId, Contributions.bobKeyGenRound1Contribution());
+        vm.stopPrank();
 
         // Verify old functionality still works
-        uint160 newOprfKeyId = 43;
+        uint160 newOprfKeyId = 44;
         vm.prank(taceoAdmin);
         vm.expectEmit(true, true, true, true);
         emit OprfKeyGen.SecretGenRound1(newOprfKeyId, 2);

--- a/test/OprfKeyRegistryUpgradeV2.t.sol
+++ b/test/OprfKeyRegistryUpgradeV2.t.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Contributions} from "./Contributions.t.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {OprfKeyGen} from "../src/OprfKeyGen.sol";
+import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {UnreleasedOprfKeyRegistryV2} from "../src/UnreleasedOprfKeyRegistryV2.sol";
+import {Test} from "forge-std/Test.sol";
+import {Verifier as VerifierKeyGen13} from "../src/VerifierKeyGen13.sol";
+
+contract OprfKeyRegistryV3Mock is UnreleasedOprfKeyRegistryV2 {
+    uint256 public newFeature;
+
+    function version() public pure returns (string memory) {
+        return "V3";
+    }
+
+    function setNewFeature(uint256 value) public {
+        newFeature = value;
+    }
+}
+
+contract OprfKeyRegistryUpgradeV2Test is Test {
+    uint256 public constant THRESHOLD = 2;
+    uint256 public constant MAX_PEERS = 3;
+
+    UnreleasedOprfKeyRegistryV2 public oprfKeyRegistryV2;
+    VerifierKeyGen13 public verifierKeyGen;
+    ERC1967Proxy public proxy;
+
+    address alice = address(0x1);
+    address bob = address(0x2);
+    address carol = address(0x3);
+    address taceoAdmin = address(0x4);
+    address initOwner = 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496;
+
+    function setUp() public {
+        verifierKeyGen = new VerifierKeyGen13();
+        UnreleasedOprfKeyRegistryV2 implementationV2 = new UnreleasedOprfKeyRegistryV2();
+        bytes memory initData = abi.encodeWithSelector(
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+        );
+        proxy = new ERC1967Proxy(address(implementationV2), initData);
+        oprfKeyRegistryV2 = UnreleasedOprfKeyRegistryV2(address(proxy));
+
+        address[] memory peerAddresses = new address[](3);
+        peerAddresses[0] = alice;
+        peerAddresses[1] = bob;
+        peerAddresses[2] = carol;
+        oprfKeyRegistryV2.registerOprfPeers(peerAddresses);
+    }
+
+    function testUpgradeFromV2ToV3Mock() public {
+        uint160 oprfKeyId = 42;
+        vm.prank(taceoAdmin);
+        oprfKeyRegistryV2.initKeyGen(oprfKeyId);
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, true, true);
+        emit UnreleasedOprfKeyRegistryV2.KeyGenStuckReported(oprfKeyId, alice, OprfKeyGen.Round.ONE);
+        oprfKeyRegistryV2.reportKeyGenStuck(oprfKeyId);
+
+        OprfKeyRegistryV3Mock implementationV3 = new OprfKeyRegistryV3Mock();
+        OprfKeyRegistry(address(proxy)).upgradeToAndCall(address(implementationV3), "");
+        OprfKeyRegistryV3Mock oprfKeyRegistryV3 = OprfKeyRegistryV3Mock(address(proxy));
+
+        assertEq(oprfKeyRegistryV3.owner(), initOwner);
+        assertEq(oprfKeyRegistryV3.keygenAdmins(taceoAdmin), true);
+
+        assertEq(oprfKeyRegistryV3.version(), "V3");
+        oprfKeyRegistryV3.setNewFeature(7);
+        assertEq(oprfKeyRegistryV3.newFeature(), 7);
+
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.WrongRound.selector, 4));
+        oprfKeyRegistryV3.addRound1KeyGenContribution(oprfKeyId, Contributions.bobKeyGenRound1Contribution());
+    }
+}

--- a/test/OprfKeyRegistryV2.t.sol
+++ b/test/OprfKeyRegistryV2.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Contributions} from "./Contributions.t.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {OprfKeyGen} from "../src/OprfKeyGen.sol";
+import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+import {UnreleasedOprfKeyRegistryV2} from "../src/UnreleasedOprfKeyRegistryV2.sol";
+import {Test} from "forge-std/Test.sol";
+import {Verifier as VerifierKeyGen13} from "../src/VerifierKeyGen13.sol";
+
+contract OprfKeyRegistryV2Test is Test {
+    uint256 public constant THRESHOLD = 2;
+    uint256 public constant MAX_PEERS = 3;
+
+    UnreleasedOprfKeyRegistryV2 public oprfKeyRegistry;
+    VerifierKeyGen13 public verifierKeyGen;
+    ERC1967Proxy public proxy;
+
+    address alice = address(0x1);
+    address bob = address(0x2);
+    address carol = address(0x3);
+    address taceoAdmin = address(0x4);
+    address initOwner = 0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496;
+
+    function setUp() public {
+        verifierKeyGen = new VerifierKeyGen13();
+        UnreleasedOprfKeyRegistryV2 implementation = new UnreleasedOprfKeyRegistryV2();
+        bytes memory initData = abi.encodeWithSelector(
+            OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
+        );
+        proxy = new ERC1967Proxy(address(implementation), initData);
+        oprfKeyRegistry = UnreleasedOprfKeyRegistryV2(address(proxy));
+
+        address[] memory peerAddresses = new address[](3);
+        peerAddresses[0] = alice;
+        peerAddresses[1] = bob;
+        peerAddresses[2] = carol;
+        oprfKeyRegistry.registerOprfPeers(peerAddresses);
+    }
+
+    function testReportKeyGenStuckFromParticipant() public {
+        uint160 oprfKeyId = 42;
+
+        vm.prank(taceoAdmin);
+        oprfKeyRegistry.initKeyGen(oprfKeyId);
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, true, true);
+        emit UnreleasedOprfKeyRegistryV2.KeyGenStuckReported(oprfKeyId, alice, OprfKeyGen.Round.ONE);
+        oprfKeyRegistry.reportKeyGenStuck(oprfKeyId);
+
+        // Bob tries to add his contribution but the round is stuck
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.WrongRound.selector, 4));
+        oprfKeyRegistry.addRound1KeyGenContribution(oprfKeyId, Contributions.bobKeyGenRound1Contribution());
+    }
+
+    function testReportKeyGenStuckRevertNonParticipant() public {
+        uint160 oprfKeyId = 42;
+
+        vm.prank(taceoAdmin);
+        oprfKeyRegistry.initKeyGen(oprfKeyId);
+
+        // Non-participant tries to report stuck
+        vm.prank(address(0xdeadbeef));
+        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.NotAParticipant.selector));
+        oprfKeyRegistry.reportKeyGenStuck(oprfKeyId);
+    }
+
+    function testReportKeyGenStuckRevertUnknownId() public {
+        uint160 oprfKeyId = 42;
+
+        vm.prank(alice);
+
+        // Key gen never started
+        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.UnknownId.selector, oprfKeyId));
+        oprfKeyRegistry.reportKeyGenStuck(oprfKeyId);
+    }
+
+    function testReportKeyGenStuckRevertWhenAlreadyStuck() public {
+        uint160 oprfKeyId = 42;
+
+        vm.prank(taceoAdmin);
+        oprfKeyRegistry.initKeyGen(oprfKeyId);
+
+        vm.prank(alice);
+        oprfKeyRegistry.reportKeyGenStuck(oprfKeyId);
+
+        // Bob tries to report stuck but the round is already stuck
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(OprfKeyRegistry.WrongRound.selector, 4));
+        oprfKeyRegistry.reportKeyGenStuck(oprfKeyId);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new state transition that any registered participant can trigger, potentially halting an active key-gen/reshare if misused. Although guarded by round checks and tests, it changes protocol flow in an upgradeable contract.
> 
> **Overview**
> Adds upgrade-target implementation `UnreleasedOprfKeyRegistryV2` with `reportKeyGenStuck(uint160)` so registered participants can force an in-progress key-gen/reshare (Rounds 1–3 only) into the `STUCK` round and emit `KeyGenStuckReported`.
> 
> Updates upgrade tests to upgrade from `OprfKeyRegistry` to V2 and validate the new stuck-reporting behavior, and adds new test suites covering V2 behavior and a follow-on upgrade (V2→V3 mock) to ensure storage/permissions survive further upgrades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96f9b34256b4a8e9128f7ea60e28e379016a5ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->