### PR TITLE
Add scripts for Safe:Wallet interaction

### DIFF
--- a/justfile
+++ b/justfile
@@ -142,6 +142,33 @@ abort-key-gen *args:
 
 [group('contract')]
 [working-directory("script")]
+transfer-ownership-dry-run *args:
+    forge script TransferOwnership.s.sol -vvvvv {{ args }}
+
+[group('contract')]
+[working-directory("script")]
+transfer-ownership *args:
+    forge script TransferOwnership.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
+
+[group('contract')]
+[working-directory("script")]
+accept-ownership-dry-run *args:
+    forge script AcceptOwnership.s.sol -vvvvv {{ args }}
+
+[group('contract')]
+[working-directory("script")]
+accept-ownership *args:
+    forge script AcceptOwnership.s.sol -vvvvv --broadcast --interactives 1 {{ args }} --rpc-url $RPC_URL
+
+# Dry-run any script as the given Safe and emit a Safe Transaction Builder JSON
+# at broadcast/<Script>/<chain_id>/safe-tx.json, ready to upload via
+# app.safe.global → Transaction Builder → Load batch.
+[group('contract')]
+safe-tx script chain_id safe_addr *args:
+    script/to-safe-tx.sh {{ script }} {{ chain_id }} {{ safe_addr }} -vvv {{ args }} --rpc-url $RPC_URL
+
+[group('contract')]
+[working-directory("script")]
 init-key-gen-dry-run *args:
     forge script InitKeyGen.s.sol -vvvvv {{ args }} --rpc-url $RPC_URL
 

--- a/script/AcceptOwnership.s.sol
+++ b/script/AcceptOwnership.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+
+contract AcceptOwnershipScript is Script {
+    OprfKeyRegistry public oprfKeyRegistry;
+
+    function setUp() public {
+        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+    }
+
+    function run() public {
+        vm.startBroadcast();
+        oprfKeyRegistry.acceptOwnership();
+        vm.stopBroadcast();
+        console.log("Accepted ownership of OprfKeyRegistry at", address(oprfKeyRegistry));
+    }
+}

--- a/script/PrintInformation.s.sol
+++ b/script/PrintInformation.s.sol
@@ -16,11 +16,13 @@ contract PrintInformationScript is Script {
         bool isContractReady = oprfKeyRegistry.isContractReady();
         uint256 amountAdmins = oprfKeyRegistry.amountKeygenAdmins();
         address keyGenVerifier = oprfKeyRegistry.keyGenVerifier();
+        address owner = oprfKeyRegistry.owner();
         uint256 threshold = oprfKeyRegistry.threshold();
         uint256 numPeers = oprfKeyRegistry.numPeers();
         console.log("isContractReady:", isContractReady);
         console.log("amountAdmins:", amountAdmins);
         console.log("keyGenVerifier:", keyGenVerifier);
+        console.log("owner:", owner);
         console.log("threshold:", threshold);
         console.log("numPeers:", numPeers);
         if (isContractReady) {

--- a/script/TransferOwnership.s.sol
+++ b/script/TransferOwnership.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
+
+contract TransferOwnershipScript is Script {
+    OprfKeyRegistry public oprfKeyRegistry;
+
+    function setUp() public {
+        oprfKeyRegistry = OprfKeyRegistry(vm.envAddress("OPRF_KEY_REGISTRY_PROXY"));
+    }
+
+    function run() public {
+        address newOwner = vm.envAddress("NEW_OWNER");
+        vm.startBroadcast();
+        oprfKeyRegistry.transferOwnership(newOwner);
+        vm.stopBroadcast();
+        console.log("Set pending owner of OprfKeyRegistry at", address(oprfKeyRegistry), "to", newOwner);
+    }
+}

--- a/script/to-safe-tx.sh
+++ b/script/to-safe-tx.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Run a Foundry script as a dry-run impersonating a Safe, then transform the
+# broadcast JSON into Safe Transaction Builder format that can be uploaded via
+# https://app.safe.global → Transaction Builder → Load batch.
+#
+# Usage:
+#   ./to-safe-tx.sh <ScriptFile.s.sol> <ChainId> <SafeAddress> [forge-script args...]
+#
+# Must be run from the `contracts/` directory (the Foundry project root), so
+# that Foundry's broadcast/ output lands where we expect it.
+#
+# Example:
+#   OPRF_KEY_REGISTRY_PROXY=0x... OPRF_KEY_ID=42 \
+#     script/to-safe-tx.sh script/AbortKeyGen.s.sol 480 0xSafeAddr \
+#       --rpc-url "$RPC_URL"
+
+set -euo pipefail
+
+usage() {
+    sed -n '2,17p' "$0"
+    exit 1
+}
+
+[[ $# -ge 3 ]] || usage
+
+SCRIPT_PATH="$1"
+CHAIN_ID="$2"
+SAFE_ADDR="$3"
+shift 3
+
+SCRIPT_BASENAME=$(basename "$SCRIPT_PATH")
+
+# --sender sets msg.sender for vm.broadcast() during simulation. No private key
+# is needed because we never pass --broadcast — this is a pure dry-run.
+forge script "$SCRIPT_PATH" --sender "$SAFE_ADDR" "$@"
+
+SRC="broadcast/${SCRIPT_BASENAME}/${CHAIN_ID}/dry-run/run-latest.json"
+OUT="broadcast/${SCRIPT_BASENAME}/${CHAIN_ID}/safe-tx.json"
+
+if [[ ! -f "$SRC" ]]; then
+    echo "error: expected broadcast file not found: $SRC" >&2
+    echo "       did the script broadcast any transactions on chain $CHAIN_ID?" >&2
+    exit 1
+fi
+
+python3 - "$SRC" "$OUT" "$CHAIN_ID" "$SAFE_ADDR" <<'PY'
+import json, sys, time
+
+src, out, chain_id, safe = sys.argv[1:]
+
+with open(src) as f:
+    data = json.load(f)
+
+transactions = []
+creates = []
+for entry in data.get("transactions", []):
+    tx_type = entry.get("transactionType", "CALL")
+    tx = entry["transaction"]
+    # Safe Transaction Builder has no way to encode a raw contract deployment
+    # (no `to` address). If you need to deploy via a Safe, rewrite the Foundry
+    # script to call a deterministic deployer (e.g. CreateX at
+    # 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed) instead of emitting CREATE.
+    if tx_type in ("CREATE", "CREATE2") or tx.get("to") is None:
+        creates.append((tx_type, entry.get("contractName") or "<unknown>"))
+        continue
+    # Foundry emits value as hex ("0x0"); Safe txBuilder wants a decimal string.
+    # int(_, 16) handles full uint256 range.
+    value_dec = str(int(tx.get("value") or "0x0", 16))
+    transactions.append({
+        "to": tx["to"],
+        "value": value_dec,
+        "data": tx["input"],
+        "contractMethod": None,
+        "contractInputsValues": None,
+    })
+
+if creates:
+    print("error: Safe Transaction Builder cannot represent contract deployments.", file=sys.stderr)
+    print("       The following transactions have no `to` address:", file=sys.stderr)
+    for tx_type, name in creates:
+        print(f"         - {tx_type:<8} {name}", file=sys.stderr)
+    print("       Rewrite the script to deploy via a factory (e.g. CreateX), or", file=sys.stderr)
+    print("       run the deploy from an EOA and only batch the post-deploy calls.", file=sys.stderr)
+    sys.exit(2)
+
+if not transactions:
+    print("error: no transactions found in broadcast file.", file=sys.stderr)
+    sys.exit(1)
+
+safe_batch = {
+    "version": "1.0",
+    "chainId": chain_id,
+    "createdAt": int(time.time() * 1000),
+    "meta": {
+        "name": "Foundry script batch",
+        "description": "",
+        "txBuilderVersion": "1.17.0",
+        "createdFromSafeAddress": safe,
+        "createdFromOwnerAddress": "",
+        "checksum": "",
+    },
+    "transactions": transactions,
+}
+
+with open(out, "w") as f:
+    json.dump(safe_batch, f, indent=2)
+
+print(f"wrote {out} ({len(transactions)} transaction(s))", file=sys.stderr)
+PY


### PR DESCRIPTION
- **feat: more scripts for Safe:Wallet interactions**
- **feat: add owner to printinformation**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new operational scripts for `transferOwnership`/`acceptOwnership` and for generating Safe Transaction Builder batches; mistakes in environment variables or usage could result in unintended on-chain admin/ownership changes.
> 
> **Overview**
> Adds Foundry scripts to manage `OprfKeyRegistry` ownership via `transferOwnership` (sets pending owner) and `acceptOwnership` (finalizes transfer), with new `just` commands for dry-run and broadcast execution.
> 
> Introduces a `safe-tx` workflow (`script/to-safe-tx.sh` + `justfile` target) that dry-runs a Foundry script impersonating a Safe and converts the resulting `broadcast/*/dry-run` JSON into a Safe Transaction Builder `safe-tx.json` batch, and extends `PrintInformation.s.sol` to log the current `owner`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f818efc6a4df6630da17970ec4868246c86da6d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->