### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly updates for each Dependabot ecosystem mapped from the detected languages on the default branch.

Detected languages: Just,Solidity

- Weekly updates for `github-actions`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Dependabot scheduling; no production code paths affected.
> 
> **Overview**
> Adds a Dependabot cooldown to the `github-actions` update configuration, delaying subsequent PRs for 3 days after an update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314fa3b7e7c8db8b7dd2d2ead72a30faa7e72a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->