### PR TITLE
themis/v2/view methods

### DIFF
--- a/src/IUnreleasedOprfKeyRegistryV2.sol
+++ b/src/IUnreleasedOprfKeyRegistryV2.sol
@@ -14,4 +14,13 @@ interface IUnreleasedOprfKeyRegistryV2 is IOprfKeyRegistry {
     /// @notice Allows a registered OPRF node to report an active key-gen/reshare is stuck.
     /// @param oprfKeyId The unique identifier for the OPRF key process.
     function reportKeyGenStuck(uint160 oprfKeyId) external;
+
+    /// @notice Returns the list of registered OPRF peer addresses, indexed by party ID.
+    /// @return The registered peer addresses in party-ID order.
+    function getPeerAddresses() external view returns (address[] memory);
+
+    /// @notice Checks whether the given address is a registered OPRF participant.
+    /// @param addr The address to check.
+    /// @return True if `addr` is a registered participant.
+    function isParticipant(address addr) external view returns (bool);
 }

--- a/src/UnreleasedOprfKeyRegistryV2.sol
+++ b/src/UnreleasedOprfKeyRegistryV2.sol
@@ -12,6 +12,7 @@ import {IUnreleasedOprfKeyRegistryV2} from "./IUnreleasedOprfKeyRegistryV2.sol";
 /// @notice Next unreleased version of `OprfKeyRegistry` intended for proxy upgrades.
 /// @dev Change list for this version:
 /// - Adds `reportKeyGenStuck(uint160)` so registered nodes can report key-generation/reshare processes as stuck.
+/// - Adds ERC165 support.
 /// @custom:oz-upgrades-from OprfKeyRegistry
 contract UnreleasedOprfKeyRegistryV2 is OprfKeyRegistry, IUnreleasedOprfKeyRegistryV2, ERC165 {
     /// @notice Allows a registered OPRF node to report an active key-gen/reshare is stuck.

--- a/src/UnreleasedOprfKeyRegistryV2.sol
+++ b/src/UnreleasedOprfKeyRegistryV2.sol
@@ -13,6 +13,8 @@ import {IUnreleasedOprfKeyRegistryV2} from "./IUnreleasedOprfKeyRegistryV2.sol";
 /// @dev Change list for this version:
 /// - Adds `reportKeyGenStuck(uint160)` so registered nodes can report key-generation/reshare processes as stuck.
 /// - Adds ERC165 support.
+/// - Adds `getPeerAddresses`. Returns the full array of addresses of registered peers
+/// - Adds `isParticipant(address addr)`. Returns true iff the provided address is in the list of participants
 /// @custom:oz-upgrades-from OprfKeyRegistry
 contract UnreleasedOprfKeyRegistryV2 is OprfKeyRegistry, IUnreleasedOprfKeyRegistryV2, ERC165 {
     /// @notice Allows a registered OPRF node to report an active key-gen/reshare is stuck.

--- a/src/UnreleasedOprfKeyRegistryV2.sol
+++ b/src/UnreleasedOprfKeyRegistryV2.sol
@@ -40,4 +40,17 @@ contract UnreleasedOprfKeyRegistryV2 is OprfKeyRegistry, IUnreleasedOprfKeyRegis
         return interfaceId == type(IOprfKeyRegistry).interfaceId
             || interfaceId == type(IUnreleasedOprfKeyRegistryV2).interfaceId || super.supportsInterface(interfaceId);
     }
+
+    /// @notice Returns the list of registered OPRF peer addresses, indexed by party ID.
+    /// @return The registered peer addresses in party-ID order.
+    function getPeerAddresses() public view virtual onlyProxy returns (address[] memory) {
+        return peerAddresses;
+    }
+
+    /// @notice Checks whether the given address is a registered OPRF participant.
+    /// @param addr The address to check.
+    /// @return True if `addr` is a registered participant.
+    function isParticipant(address addr) public view virtual onlyProxy returns (bool) {
+        return addressToPeer[addr].isParticipant;
+    }
 }

--- a/test/OprfKeyRegistryV2.t.sol
+++ b/test/OprfKeyRegistryV2.t.sol
@@ -94,4 +94,17 @@ contract OprfKeyRegistryV2Test is Test {
         vm.expectRevert(abi.encodeWithSelector(IOprfKeyRegistry.WrongRound.selector, 4));
         oprfKeyRegistry.reportKeyGenStuck(oprfKeyId);
     }
+
+    function testGetPeerAddresses() public view {
+        address[] memory peers = oprfKeyRegistry.getPeerAddresses();
+        assertEq(peers.length, 3);
+        assertEq(peers[0], alice);
+        assertEq(peers[1], bob);
+        assertEq(peers[2], carol);
+    }
+
+    function testIsParticipant() public view {
+        assertTrue(oprfKeyRegistry.isParticipant(alice));
+        assertFalse(oprfKeyRegistry.isParticipant(address(0xdeadbeef)));
+    }
 }


### PR DESCRIPTION
- **chore: add doc comment highlighting ERC165 support**
- **feat: add helpers to v2 contract for peer retrieval**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only view functions over existing registry state; no auth or key-gen logic changes.
> 
> **Overview**
> Adds **read-only V2 API** on `UnreleasedOprfKeyRegistryV2` so integrators can list registered OPRF peers in party-ID order via `getPeerAddresses()` and check membership with `isParticipant(address)`, both declared on `IUnreleasedOprfKeyRegistryV2` and implemented with `onlyProxy` against existing `peerAddresses` / `addressToPeer` storage.
> 
> The contract **dev changelog** now explicitly calls out ERC165 support alongside these helpers. **Tests** assert the three registered peers and that unknown addresses are not participants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae0a1739780b3fe136d4fcadeea5d2bfa194aa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->