### PR TITLE
themis/prepare release [TAC-1017]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+permissions: {}
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Generate release notes
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: RELEASE_NOTES.md
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: RELEASE_NOTES.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,39 @@ All notable changes to this project will be documented in this file.
 
 ### ⛰️ Features
 
-- Added changeVerifierContract method (#34) ([3c2a8b6](https://github.com/TaceoLabs/oprf-key-registry/commit/3c2a8b6c3e12f204d2ab96124941f39d6ca76097))
 - Allow nodes to report key gen stuck (#41) ([2422112](https://github.com/TaceoLabs/oprf-key-registry/commit/24221126014cc12fb569e9ca5180247552a46668))
 - Added ERC165 support for key-registry ([4d291d4](https://github.com/TaceoLabs/oprf-key-registry/commit/4d291d40e49cc56dcd9e6140589940f5444d01e3))
 - Added state getters to interface for v1 ([1a2decb](https://github.com/TaceoLabs/oprf-key-registry/commit/1a2decbfb986f02a1122237a9f805e67f4513912))
 - Add helpers to v2 contract for peer retrieval ([936bd43](https://github.com/TaceoLabs/oprf-key-registry/commit/936bd433b6f9e9d309482ee20c5007215339e7dc))
+
+### 🚜 Refactor
+
+- Moved interfaces to dedicated file ([6f038bb](https://github.com/TaceoLabs/oprf-key-registry/commit/6f038bb25d6aa65455e5a8ff67251f59e1f0b036))
+
+### 🏗️ Build
+
+- Added change verifier script and just commands (#36) ([93e4f28](https://github.com/TaceoLabs/oprf-key-registry/commit/93e4f28ac48791be0eb28da16fb2e114bfe3add6))
+- Bump actions/setup-node from 4 to 6 (#45) ([5eba78a](https://github.com/TaceoLabs/oprf-key-registry/commit/5eba78ae4ba2469f6d480cf0f2a19a201cc8e46f))
+- Bump actions/checkout from 5 to 6 (#46) ([5fb6b50](https://github.com/TaceoLabs/oprf-key-registry/commit/5fb6b50eee5447626a41951b7a2bfdb332c0ac30))
+- Bump actions/checkout from 6 to 7 (#49) ([e94ee7f](https://github.com/TaceoLabs/oprf-key-registry/commit/e94ee7ffba0a798469ba64f36463af44f8640998))
+- Add scripts for Safe:Wallet interaction (#42) ([b4b2347](https://github.com/TaceoLabs/oprf-key-registry/commit/b4b234797947a58ad32d8cbb4ff888a4b3db7780))
+- Rename v2 contracts ([26ba5ee](https://github.com/TaceoLabs/oprf-key-registry/commit/26ba5ee7c07982f3b128abb15e763a786f4decdc))
+
+### 📚 Documentation
+
+- Add contract audits (#39) ([7a4ee8b](https://github.com/TaceoLabs/oprf-key-registry/commit/7a4ee8b66d2dbe44cfd559dd7cc6146d627c31a3))
+- Added docs for unreleased v2 ([cae0a17](https://github.com/TaceoLabs/oprf-key-registry/commit/cae0a1739780b3fe136d4fcadeea5d2bfa194aa1))
+- Use inheritdocs (#52) ([ddc5060](https://github.com/TaceoLabs/oprf-key-registry/commit/ddc50600b720c02e535cbf67ad0ea70f04b3a1d2))
+
+### 🧪 Testing
+
+- Add test for ERC165 support ([56d42d9](https://github.com/TaceoLabs/oprf-key-registry/commit/56d42d9c249aa21c72f5841a47366a5a6d7584fd))
+
+## [1.0.0] - 2026-02-27
+
+### ⛰️ Features
+
+- Added changeVerifierContract method (#34) ([3c2a8b6](https://github.com/TaceoLabs/oprf-key-registry/commit/3c2a8b6c3e12f204d2ab96124941f39d6ca76097))
 
 ### 🐛 Bug Fixes
 
@@ -22,7 +50,6 @@ All notable changes to this project will be documented in this file.
 
 - [**breaking**] Remove the storage gap from key-registry ([b16376c](https://github.com/TaceoLabs/oprf-key-registry/commit/b16376caecd6ccc0b904bdadc8164b4e8c90ad03))
 - [**breaking**] Removed the babyjubjub lib and extracted in dedicated lib (#37) ([0042884](https://github.com/TaceoLabs/oprf-key-registry/commit/00428849d269192703e0901145a2723e82b34f1c))
-- Moved interfaces to dedicated file ([6f038bb](https://github.com/TaceoLabs/oprf-key-registry/commit/6f038bb25d6aa65455e5a8ff67251f59e1f0b036))
 
 ### 🏗️ Build
 
@@ -30,24 +57,15 @@ All notable changes to this project will be documented in this file.
 - Added justfile ([090efa5](https://github.com/TaceoLabs/oprf-key-registry/commit/090efa5e0ca46590bb879432164e1eec81326854))
 - Added deploy and upgrade proxy scripts ([b8e6396](https://github.com/TaceoLabs/oprf-key-registry/commit/b8e63964230536e15fbcd6a41addf8fbf3d39029))
 - Added two just commands (#33) ([e387586](https://github.com/TaceoLabs/oprf-key-registry/commit/e387586d3850927b77c6ddbd36ef6180f4996eaf))
-- Added change verifier script and just commands (#36) ([93e4f28](https://github.com/TaceoLabs/oprf-key-registry/commit/93e4f28ac48791be0eb28da16fb2e114bfe3add6))
-- Bump actions/setup-node from 4 to 6 (#45) ([5eba78a](https://github.com/TaceoLabs/oprf-key-registry/commit/5eba78ae4ba2469f6d480cf0f2a19a201cc8e46f))
-- Bump actions/checkout from 5 to 6 (#46) ([5fb6b50](https://github.com/TaceoLabs/oprf-key-registry/commit/5fb6b50eee5447626a41951b7a2bfdb332c0ac30))
-- Bump actions/checkout from 6 to 7 (#49) ([e94ee7f](https://github.com/TaceoLabs/oprf-key-registry/commit/e94ee7ffba0a798469ba64f36463af44f8640998))
-- Add scripts for Safe:Wallet interaction (#42) ([b4b2347](https://github.com/TaceoLabs/oprf-key-registry/commit/b4b234797947a58ad32d8cbb4ff888a4b3db7780))
 
 ### 📚 Documentation
 
 - Update Readme (#29) ([e3269dd](https://github.com/TaceoLabs/oprf-key-registry/commit/e3269dd040aca0352271753233f2bd8e8a4a9d96))
-- Add contract audits (#39) ([7a4ee8b](https://github.com/TaceoLabs/oprf-key-registry/commit/7a4ee8b66d2dbe44cfd559dd7cc6146d627c31a3))
-- Added docs for unreleased v2 ([cae0a17](https://github.com/TaceoLabs/oprf-key-registry/commit/cae0a1739780b3fe136d4fcadeea5d2bfa194aa1))
-- Use inheritdocs (#52) ([ddc5060](https://github.com/TaceoLabs/oprf-key-registry/commit/ddc50600b720c02e535cbf67ad0ea70f04b3a1d2))
 
 ### 🧪 Testing
 
 - Add wrong-round event for key-registry-mock (#26) ([2837db7](https://github.com/TaceoLabs/oprf-key-registry/commit/2837db7863a6dd85e9605d7561952432851b9e9e))
 - Add finalize_event for mock contract (#27) ([895ad65](https://github.com/TaceoLabs/oprf-key-registry/commit/895ad65957d3f83f8ec54fdfc03ff941e9affd1b))
-- Add test for ERC165 support ([56d42d9](https://github.com/TaceoLabs/oprf-key-registry/commit/56d42d9c249aa21c72f5841a47366a5a6d7584fd))
 
 ## [1.0.0-rc.1] - 2026-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,125 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### ⛰️ Features
+
+- Added changeVerifierContract method (#34) ([3c2a8b6](https://github.com/TaceoLabs/oprf-key-registry/commit/3c2a8b6c3e12f204d2ab96124941f39d6ca76097))
+- Allow nodes to report key gen stuck (#41) ([2422112](https://github.com/TaceoLabs/oprf-key-registry/commit/24221126014cc12fb569e9ca5180247552a46668))
+- Added ERC165 support for key-registry ([4d291d4](https://github.com/TaceoLabs/oprf-key-registry/commit/4d291d40e49cc56dcd9e6140589940f5444d01e3))
+- Added state getters to interface for v1 ([1a2decb](https://github.com/TaceoLabs/oprf-key-registry/commit/1a2decbfb986f02a1122237a9f805e67f4513912))
+- Add helpers to v2 contract for peer retrieval ([936bd43](https://github.com/TaceoLabs/oprf-key-registry/commit/936bd433b6f9e9d309482ee20c5007215339e7dc))
+
+### 🐛 Bug Fixes
+
+- Prevents reseting a deleted key if abort is called ([61f492c](https://github.com/TaceoLabs/oprf-key-registry/commit/61f492cc55247b2d26d79314409f6b88231cd980))
+- Adds uniquness check for eph public keys to prevent replay attacks ([824e6bb](https://github.com/TaceoLabs/oprf-key-registry/commit/824e6bb42cca37931442ebc30fbfa002f32413d2))
+- Update working directory in justfile ([1e0c7c2](https://github.com/TaceoLabs/oprf-key-registry/commit/1e0c7c25853113a874ad359256864c1c8bbdeabf))
+
+### 🚜 Refactor
+
+- [**breaking**] Remove the storage gap from key-registry ([b16376c](https://github.com/TaceoLabs/oprf-key-registry/commit/b16376caecd6ccc0b904bdadc8164b4e8c90ad03))
+- [**breaking**] Removed the babyjubjub lib and extracted in dedicated lib (#37) ([0042884](https://github.com/TaceoLabs/oprf-key-registry/commit/00428849d269192703e0901145a2723e82b34f1c))
+- Moved interfaces to dedicated file ([6f038bb](https://github.com/TaceoLabs/oprf-key-registry/commit/6f038bb25d6aa65455e5a8ff67251f59e1f0b036))
+
+### 🏗️ Build
+
+- Add upgradeable proxy check in ci (#31) ([c4b6c12](https://github.com/TaceoLabs/oprf-key-registry/commit/c4b6c12f4a32d6ebc526c2ab562df722f13f0910))
+- Added justfile ([090efa5](https://github.com/TaceoLabs/oprf-key-registry/commit/090efa5e0ca46590bb879432164e1eec81326854))
+- Added deploy and upgrade proxy scripts ([b8e6396](https://github.com/TaceoLabs/oprf-key-registry/commit/b8e63964230536e15fbcd6a41addf8fbf3d39029))
+- Added two just commands (#33) ([e387586](https://github.com/TaceoLabs/oprf-key-registry/commit/e387586d3850927b77c6ddbd36ef6180f4996eaf))
+- Added change verifier script and just commands (#36) ([93e4f28](https://github.com/TaceoLabs/oprf-key-registry/commit/93e4f28ac48791be0eb28da16fb2e114bfe3add6))
+- Bump actions/setup-node from 4 to 6 (#45) ([5eba78a](https://github.com/TaceoLabs/oprf-key-registry/commit/5eba78ae4ba2469f6d480cf0f2a19a201cc8e46f))
+- Bump actions/checkout from 5 to 6 (#46) ([5fb6b50](https://github.com/TaceoLabs/oprf-key-registry/commit/5fb6b50eee5447626a41951b7a2bfdb332c0ac30))
+- Bump actions/checkout from 6 to 7 (#49) ([e94ee7f](https://github.com/TaceoLabs/oprf-key-registry/commit/e94ee7ffba0a798469ba64f36463af44f8640998))
+- Add scripts for Safe:Wallet interaction (#42) ([b4b2347](https://github.com/TaceoLabs/oprf-key-registry/commit/b4b234797947a58ad32d8cbb4ff888a4b3db7780))
+
+### 📚 Documentation
+
+- Update Readme (#29) ([e3269dd](https://github.com/TaceoLabs/oprf-key-registry/commit/e3269dd040aca0352271753233f2bd8e8a4a9d96))
+- Add contract audits (#39) ([7a4ee8b](https://github.com/TaceoLabs/oprf-key-registry/commit/7a4ee8b66d2dbe44cfd559dd7cc6146d627c31a3))
+- Added docs for unreleased v2 ([cae0a17](https://github.com/TaceoLabs/oprf-key-registry/commit/cae0a1739780b3fe136d4fcadeea5d2bfa194aa1))
+- Use inheritdocs (#52) ([ddc5060](https://github.com/TaceoLabs/oprf-key-registry/commit/ddc50600b720c02e535cbf67ad0ea70f04b3a1d2))
+
+### 🧪 Testing
+
+- Add wrong-round event for key-registry-mock (#26) ([2837db7](https://github.com/TaceoLabs/oprf-key-registry/commit/2837db7863a6dd85e9605d7561952432851b9e9e))
+- Add finalize_event for mock contract (#27) ([895ad65](https://github.com/TaceoLabs/oprf-key-registry/commit/895ad65957d3f83f8ec54fdfc03ff941e9affd1b))
+- Add test for ERC165 support ([56d42d9](https://github.com/TaceoLabs/oprf-key-registry/commit/56d42d9c249aa21c72f5841a47366a5a6d7584fd))
+
+## [1.0.0-rc.1] - 2026-02-10
+
+### ⛰️ Features
+
+- Added admin methods to interface (#21) ([2fb77a1](https://github.com/TaceoLabs/oprf-key-registry/commit/2fb77a1ff33622671fe019d845ed8823d0e79ecd))
+- Emit an event if one of the registered OPRF peers changes. (#25) ([30eff1a](https://github.com/TaceoLabs/oprf-key-registry/commit/30eff1a8ef7bc2274b7daf01a51d3980cc18eb20))
+
+### 🐛 Bug Fixes
+
+- Remove leftover constants from contract ([817107a](https://github.com/TaceoLabs/oprf-key-registry/commit/817107a2bfaa842e477917f89c0a5274cff1cb1c))
+
+### 🚜 Refactor
+
+- Make party id indexable in KeyGenConfirmation (#18) ([6b90a47](https://github.com/TaceoLabs/oprf-key-registry/commit/6b90a47bcadde15f4a82911c4f64118db24315b6))
+- [**breaking**] Explicitly pass in the owner into the contract during init ([c8042bf](https://github.com/TaceoLabs/oprf-key-registry/commit/c8042bfc2e54b531c7a5ab7b3fbea51169a18837))
+- [**breaking**] Set epoch to be a u32 (#24) ([0baafb8](https://github.com/TaceoLabs/oprf-key-registry/commit/0baafb81d9190e7a0a9c39a19b06ec09378030c0))
+
+### 🧪 Testing
+
+- Added mock oprf key-registry (#19) ([2c2a17c](https://github.com/TaceoLabs/oprf-key-registry/commit/2c2a17c59f6c5e6a806cde36483829accac0df97))
+- Added mocked version for invalid proof test (#23) ([a655038](https://github.com/TaceoLabs/oprf-key-registry/commit/a655038ad4496683ae7f53b56c0e3dcb37230e24))
+
+## [1.0.0-beta.1] - 2026-01-20
+
+### ⛰️ Features
+
+- Add IOprfKeyRegistry interface (#9) ([95ce183](https://github.com/TaceoLabs/oprf-key-registry/commit/95ce18337f14b086ed0a3704dddee2095b95d849))
+- Add abort functionality to KeyReshare (#5) ([2d58b77](https://github.com/TaceoLabs/oprf-key-registry/commit/2d58b77a317858dc1688e547c4eab5b598bd7814))
+- Prevents initKeyGen with id 0 (#11) ([4b23ebe](https://github.com/TaceoLabs/oprf-key-registry/commit/4b23ebecc6026fb6426db7c503f42993a81bb072))
+- Allow owner to add key-gen admins as well ([79b9b04](https://github.com/TaceoLabs/oprf-key-registry/commit/79b9b0426ccc53ae856bc2d984d84e4f47c9b9dc))
+- [**breaking**] WrongRound error not wraps the current round ([2b37c31](https://github.com/TaceoLabs/oprf-key-registry/commit/2b37c3122775cb72ac79d3cc5d973829058fe6bb))
+
+### 🐛 Bug Fixes
+
+- Generated epoch in round3 event now correct #8 ([53f901e](https://github.com/TaceoLabs/oprf-key-registry/commit/53f901eafc1bb94686596178c4507361f189f8d2))
+- Removed unnecessary delete of nodeRoles ([1b4e01e](https://github.com/TaceoLabs/oprf-key-registry/commit/1b4e01e329dbdf7bf67822a6d2c4ee6a0ec9869c))
+- Fixed stuck event and added test ([1e43143](https://github.com/TaceoLabs/oprf-key-registry/commit/1e4314352afb5817576bcbff3d1a674829483406))
+- Fixed the round checks for loading pks/ciphers (#14) ([174f83b](https://github.com/TaceoLabs/oprf-key-registry/commit/174f83b0e54f971af54818a7254d0c1eb7e7e958))
+
+### 🚜 Refactor
+
+- Revert nonce to transaction confirmation event (#4)" (#6) ([bec8eb5](https://github.com/TaceoLabs/oprf-key-registry/commit/bec8eb54f4e7de5f0b25a2c3b77308e7c9039512))
+- [**breaking**] Rewrote babyjubjub to library ([e339fe9](https://github.com/TaceoLabs/oprf-key-registry/commit/e339fe95ded4e15ee5d4c8111c5e7564f9ed5e92))
+- [**breaking**] Move functionallity of key-gen into types library ([a0f2b63](https://github.com/TaceoLabs/oprf-key-registry/commit/a0f2b63f8cecbffba742537f55d51b02481ffaa6))
+- [**breaking**] Renamed Types library to OprfKeyGen library ([ddb5569](https://github.com/TaceoLabs/oprf-key-registry/commit/ddb5569bb31a6300add2a2ac27bbe05ec0631e33))
+- Moved from external calls to public calls ([7ec48ad](https://github.com/TaceoLabs/oprf-key-registry/commit/7ec48adaab7511fc489b40dbdde376b05a37189f))
+
+### 🏗️ Build
+
+- Removed babyjubjub contract from deploy scripts ([b2b8678](https://github.com/TaceoLabs/oprf-key-registry/commit/b2b8678bcf16a88f664e68a6790d68ba262fdbe5))
+
+### 📚 Documentation
+
+- Update broken doc in BabyJubJub.sol ([b1000f9](https://github.com/TaceoLabs/oprf-key-registry/commit/b1000f93d802d885a08e2c18e9472f4300797424))
+
+### 🧪 Testing
+
+- Added kats for reshare once and twice (#10) ([42c8ba0](https://github.com/TaceoLabs/oprf-key-registry/commit/42c8ba04c0f36f9400dea07d5536f644aa2a5431))
+
+## [0.1.0-beta.1] - 2026-01-13
+
+### ⛰️ Features
+
+- Update key-gen verifier contracts and tests for latest circuits (#2) ([2f85b8c](https://github.com/TaceoLabs/oprf-key-registry/commit/2f85b8cfd1d064187fef8bf5026f6be71f94e027))
+- Contract add nonce to transaction confirmation event (#4) ([509a11d](https://github.com/TaceoLabs/oprf-key-registry/commit/509a11dcc712c15cf3037ba8aa52e100b6fc647a))
+
+### 🐛 Bug Fixes
+
+- Now only checks commitments in round 1 reshare if producer ([9670d10](https://github.com/TaceoLabs/oprf-key-registry/commit/9670d10bba7e881e98f0bd658bc24de80bedd407))
+
+### 🚜 Refactor
+
+- Round 2 event now also emits generated epoch ([8d48cad](https://github.com/TaceoLabs/oprf-key-registry/commit/8d48cad453e607108d5afeef01235443ad12833b))
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,7 +46,7 @@ it serves as the reference for storage-layout validation of the next version.
 2. Execute the upgrade from the proxy owner. Set `OPRF_KEY_REGISTRY_PROXY` and
    `OPRF_KEY_REGISTRY_NEW_IMPL`, then either run `just upgrade-oprf-key-registry` directly, or,
    when the owner is a Safe, generate a Transaction Builder batch with
-   `just safe-tx deploy/UpgradeOprfKeyRegistry.s.sol <chain_id> <safe_addr>` and upload it via
+   `just safe-tx script/deploy/UpgradeOprfKeyRegistry.s.sol <chain_id> <safe_addr>` and upload it via
    app.safe.global.
 3. Verify the new implementation on the block explorer and check the proxy reports the new
    version (e.g. `supportsInterface` for v2+).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,52 @@
+# Releasing
+
+The registry is a UUPS-upgradeable contract behind an `ERC1967Proxy`. The released, deployed
+version keeps its contract name forever (v1 is `OprfKeyRegistry`, v2 is `OprfKeyRegistryV2`, ...);
+it serves as the reference for storage-layout validation of the next version.
+
+## Staging the next version
+
+1. Create `src/Unreleased<Name>VN.sol` with a contract that **inherits the previous released
+   version** (e.g. `contract UnreleasedOprfKeyRegistryV3 is OprfKeyRegistryV2`). Storage is
+   append-only via inheritance: never modify or reorder state in a released contract, only append
+   new variables in the derived contract. There is intentionally no `__gap` (see the note in
+   `OprfKeyRegistry.sol`).
+2. Annotate the contract with `/// @custom:oz-upgrades-from <PreviousContract>` and keep a
+   NatSpec change list of everything the version adds.
+3. If the new version adds state that needs initialization, add an
+   `initializeVN() reinitializer(N)` function and call it via `upgradeToAndCall`.
+4. CI validates upgrade safety on every push (`.github/workflows/is_upgradable.yml`, backed by
+   `@openzeppelin/upgrades-core validate`). Run it locally with:
+
+   ```sh
+   forge clean && forge build
+   npx @openzeppelin/upgrades-core validate --unsafeAllowLinkedLibraries --exclude "**/*.t.sol"
+   ```
+
+5. Add tests: behavior tests for the new functions, and an upgrade test that deploys the previous
+   version, runs a flow, upgrades, and asserts state is preserved (pattern:
+   `test/OprfKeyRegistryUpgrade.t.sol`).
+
+## Cutting a release
+
+1. Rename the staged files and contracts, dropping the `Unreleased` prefix
+   (`UnreleasedOprfKeyRegistryV3` -> `OprfKeyRegistryV3`), and update all references in
+   `test/` and `script/deploy/`. Keep the `@custom:oz-upgrades-from` annotation.
+2. Point the deploy scripts at the new version so fresh deployments start on it
+   (`script/deploy/OprfKeyRegistryImpl.s.sol`, `OprfKeyRegistry.s.sol`,
+   `OprfKeyRegistryWithDeps.s.sol`).
+3. Regenerate the changelog: `just changelog` (git-cliff over conventional commits, config in
+   `cliff.toml`).
+4. Merge, then tag: `git tag vX.Y.Z && git push origin vX.Y.Z`. The tag triggers
+   `.github/workflows/release.yml`, which creates a GitHub Release with git-cliff notes.
+
+## Upgrading the deployed proxy
+
+1. Deploy the new implementation: `just deploy-oprf-key-registry-impl` (dry-run variant available).
+2. Execute the upgrade from the proxy owner. Set `OPRF_KEY_REGISTRY_PROXY` and
+   `OPRF_KEY_REGISTRY_NEW_IMPL`, then either run `just upgrade-oprf-key-registry` directly, or,
+   when the owner is a Safe, generate a Transaction Builder batch with
+   `just safe-tx deploy/UpgradeOprfKeyRegistry.s.sol <chain_id> <safe_addr>` and upload it via
+   app.safe.global.
+3. Verify the new implementation on the block explorer and check the proxy reports the new
+   version (e.g. `supportsInterface` for v2+).

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,54 @@
+# git-cliff configuration, see https://git-cliff.org/docs/configuration
+# Regenerate the changelog with `just changelog`.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {% if commit.breaking %}[**breaking**] {% endif %}\
+{{ commit.message | upper_first }} \
+([{{ commit.id | truncate(length=7, end="") }}](https://github.com/TaceoLabs/oprf-key-registry/commit/{{ commit.id }}))\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->⛰️ Features" },
+  { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+  { message = "^refactor\\(clippy\\)", skip = true },
+  { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+  { message = "^build", group = "<!-- 3 -->🏗️ Build" },
+  { message = "^doc", group = "<!-- 4 -->📚 Documentation" },
+  { message = "^perf", group = "<!-- 5 -->⚡ Performance" },
+  { message = "^style", group = "<!-- 6 -->🎨 Styling" },
+  { message = "^test", group = "<!-- 7 -->🧪 Testing" },
+  { message = "^chore\\(release\\):", skip = true },
+  { message = "^chore: release", skip = true },
+  { message = "^chore\\(deps.*\\)", skip = true },
+  { message = "^chore\\(pr\\)", skip = true },
+  { message = "^chore\\(pull\\)", skip = true },
+  { message = "^chore\\(npm\\).*yarn\\.lock", skip = true },
+  { message = "^chore|^ci", skip = true },
+  { body = ".*security", group = "<!-- 9 -->🛡️ Security" },
+  { message = "^revert", group = "<!-- 10 -->◀️ Revert" },
+]
+protect_breaking_commits = true
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"

--- a/cliff.toml
+++ b/cliff.toml
@@ -31,22 +31,15 @@ filter_unconventional = true
 commit_parsers = [
   { message = "^feat", group = "<!-- 0 -->⛰️ Features" },
   { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
-  { message = "^refactor\\(clippy\\)", skip = true },
   { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
   { message = "^build", group = "<!-- 3 -->🏗️ Build" },
   { message = "^doc", group = "<!-- 4 -->📚 Documentation" },
   { message = "^perf", group = "<!-- 5 -->⚡ Performance" },
   { message = "^style", group = "<!-- 6 -->🎨 Styling" },
   { message = "^test", group = "<!-- 7 -->🧪 Testing" },
-  { message = "^chore\\(release\\):", skip = true },
-  { message = "^chore: release", skip = true },
-  { message = "^chore\\(deps.*\\)", skip = true },
-  { message = "^chore\\(pr\\)", skip = true },
-  { message = "^chore\\(pull\\)", skip = true },
-  { message = "^chore\\(npm\\).*yarn\\.lock", skip = true },
+  { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+  { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
   { message = "^chore|^ci", skip = true },
-  { body = ".*security", group = "<!-- 9 -->🛡️ Security" },
-  { message = "^revert", group = "<!-- 10 -->◀️ Revert" },
 ]
 protect_breaking_commits = true
 filter_commits = false

--- a/justfile
+++ b/justfile
@@ -11,6 +11,11 @@ deploy_verify_flags := "--verify --verifier etherscan --etherscan-api-key $ETHER
 contract-tests:
     forge test
 
+# Regenerate CHANGELOG.md from conventional commits (see cliff.toml)
+[group('release')]
+changelog:
+    npx --yes git-cliff -o CHANGELOG.md
+
 [group('build')]
 show-contract-errors:
     forge inspect src/OprfKeyRegistry.sol:OprfKeyRegistry errors

--- a/script/deploy/OprfKeyRegistry.s.sol
+++ b/script/deploy/OprfKeyRegistry.s.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
 import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../../src/OprfKeyRegistryV2.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract DeployOprfKeyRegistryScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
     ERC1967Proxy public proxy;
 
     function setUp() public {}
@@ -26,17 +27,17 @@ contract DeployOprfKeyRegistryScript is Script {
         console.log("using numPeers:", numPeers);
 
         // Deploy implementation
-        OprfKeyRegistry implementation = new OprfKeyRegistry();
+        OprfKeyRegistryV2 implementation = new OprfKeyRegistryV2();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
             OprfKeyRegistry.initialize.selector, owner, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);
-        oprfKeyRegistry = OprfKeyRegistry(address(proxy));
+        oprfKeyRegistry = OprfKeyRegistryV2(address(proxy));
 
         vm.stopBroadcast();
-        console.log("OprfKeyRegistry implementation deployed to:", address(implementation));
+        console.log("OprfKeyRegistryV2 implementation deployed to:", address(implementation));
         console.log("OprfKeyRegistry proxy deployed to:", address(oprfKeyRegistry));
     }
 }

--- a/script/deploy/OprfKeyRegistryImpl.s.sol
+++ b/script/deploy/OprfKeyRegistryImpl.s.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
-import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../../src/OprfKeyRegistryV2.sol";
 
 contract DeployOprfKeyRegistryImplScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
 
     function setUp() public {}
 
@@ -13,9 +13,9 @@ contract DeployOprfKeyRegistryImplScript is Script {
         vm.startBroadcast();
 
         // Deploy implementation
-        OprfKeyRegistry implementation = new OprfKeyRegistry();
+        OprfKeyRegistryV2 implementation = new OprfKeyRegistryV2();
 
         vm.stopBroadcast();
-        console.log("OprfKeyRegistry implementation deployed to:", address(implementation));
+        console.log("OprfKeyRegistryV2 implementation deployed to:", address(implementation));
     }
 }

--- a/script/deploy/OprfKeyRegistryWithDeps.s.sol
+++ b/script/deploy/OprfKeyRegistryWithDeps.s.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.20;
 
 import {Script, console} from "forge-std/Script.sol";
 import {OprfKeyRegistry} from "../../src/OprfKeyRegistry.sol";
+import {OprfKeyRegistryV2} from "../../src/OprfKeyRegistryV2.sol";
 import {Verifier as VerifierKeyGen13} from "../../src/VerifierKeyGen13.sol";
 import {Verifier as VerifierKeyGen25} from "../../src/VerifierKeyGen25.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract DeployOprfKeyRegistryWithDepsScript is Script {
-    OprfKeyRegistry public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
     ERC1967Proxy public proxy;
 
     function setUp() public {}
@@ -37,16 +38,16 @@ contract DeployOprfKeyRegistryWithDepsScript is Script {
 
         address keyGenVerifierAddress = deployGroth16VerifierKeyGen(threshold, numPeers);
         // Deploy implementation
-        OprfKeyRegistry implementation = new OprfKeyRegistry();
+        OprfKeyRegistryV2 implementation = new OprfKeyRegistryV2();
         // Encode initializer call
         bytes memory initData = abi.encodeWithSelector(
             OprfKeyRegistry.initialize.selector, owner, taceoAdminAddress, keyGenVerifierAddress, threshold, numPeers
         );
         // Deploy proxy
         proxy = new ERC1967Proxy(address(implementation), initData);
-        oprfKeyRegistry = OprfKeyRegistry(address(proxy));
+        oprfKeyRegistry = OprfKeyRegistryV2(address(proxy));
 
-        console.log("OprfKeyRegistry implementation deployed to:", address(implementation));
+        console.log("OprfKeyRegistryV2 implementation deployed to:", address(implementation));
         console.log("OprfKeyRegistry proxy deployed to:", address(oprfKeyRegistry));
     }
 }

--- a/src/IOprfKeyRegistryV2.sol
+++ b/src/IOprfKeyRegistryV2.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import {IOprfKeyRegistry} from "./IOprfKeyRegistry.sol";
 import {OprfKeyGen} from "./OprfKeyGen.sol";
 
-interface IUnreleasedOprfKeyRegistryV2 is IOprfKeyRegistry {
+interface IOprfKeyRegistryV2 is IOprfKeyRegistry {
     /// @notice Emitted when `reportKeyGenStuck` marks an active key-gen/reshare process as stuck.
     /// @param oprfKeyId The unique identifier for the OPRF key process.
     /// @param reporter The registered OPRF peer that reported the process as stuck.

--- a/src/OprfKeyRegistryV2.sol
+++ b/src/OprfKeyRegistryV2.sol
@@ -6,18 +6,18 @@ import {OprfKeyRegistry} from "./OprfKeyRegistry.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import {IOprfKeyRegistry} from "./IOprfKeyRegistry.sol";
-import {IUnreleasedOprfKeyRegistryV2} from "./IUnreleasedOprfKeyRegistryV2.sol";
+import {IOprfKeyRegistryV2} from "./IOprfKeyRegistryV2.sol";
 
-/// @title Unreleased OPRF Key Registry V2
-/// @notice Next unreleased version of `OprfKeyRegistry` intended for proxy upgrades.
+/// @title OPRF Key Registry V2
+/// @notice Second version of `OprfKeyRegistry`, deployed via proxy upgrade from `OprfKeyRegistry`.
 /// @dev Change list for this version:
 /// - Adds `reportKeyGenStuck(uint160)` so registered nodes can report key-generation/reshare processes as stuck.
 /// - Adds ERC165 support.
 /// - Adds `getPeerAddresses`. Returns the full array of addresses of registered peers
 /// - Adds `isParticipant(address addr)`. Returns true iff the provided address is in the list of participants
 /// @custom:oz-upgrades-from OprfKeyRegistry
-contract UnreleasedOprfKeyRegistryV2 is OprfKeyRegistry, IUnreleasedOprfKeyRegistryV2, ERC165 {
-    /// @inheritdoc IUnreleasedOprfKeyRegistryV2
+contract OprfKeyRegistryV2 is OprfKeyRegistry, IOprfKeyRegistryV2, ERC165 {
+    /// @inheritdoc IOprfKeyRegistryV2
     function reportKeyGenStuck(uint160 oprfKeyId) public virtual onlyProxy isReady {
         if (!addressToPeer[msg.sender].isParticipant) revert NotAParticipant();
 
@@ -38,16 +38,16 @@ contract UnreleasedOprfKeyRegistryV2 is OprfKeyRegistry, IUnreleasedOprfKeyRegis
     }
 
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == type(IOprfKeyRegistry).interfaceId
-            || interfaceId == type(IUnreleasedOprfKeyRegistryV2).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IOprfKeyRegistry).interfaceId || interfaceId == type(IOprfKeyRegistryV2).interfaceId
+            || super.supportsInterface(interfaceId);
     }
 
-    /// @inheritdoc IUnreleasedOprfKeyRegistryV2
+    /// @inheritdoc IOprfKeyRegistryV2
     function getPeerAddresses() public view virtual onlyProxy returns (address[] memory) {
         return peerAddresses;
     }
 
-    /// @inheritdoc IUnreleasedOprfKeyRegistryV2
+    /// @inheritdoc IOprfKeyRegistryV2
     function isParticipant(address addr) public view virtual onlyProxy returns (bool) {
         return addressToPeer[addr].isParticipant;
     }

--- a/test/OprfKeyRegistryUpgrade.t.sol
+++ b/test/OprfKeyRegistryUpgrade.t.sol
@@ -6,10 +6,10 @@ import {Contributions} from "./Contributions.t.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IOprfKeyRegistry} from "../src/IOprfKeyRegistry.sol";
-import {IUnreleasedOprfKeyRegistryV2} from "../src/IUnreleasedOprfKeyRegistryV2.sol";
+import {IOprfKeyRegistryV2} from "../src/IOprfKeyRegistryV2.sol";
 import {OprfKeyGen} from "../src/OprfKeyGen.sol";
 import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
-import {UnreleasedOprfKeyRegistryV2} from "../src/UnreleasedOprfKeyRegistryV2.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {Test} from "forge-std/Test.sol";
@@ -143,11 +143,11 @@ contract OprfKeyRegistryUpgradeTest is Test {
         assertEq(oprfKey.y, Contributions.SHOULD_OPRF_PUBLIC_KEY_Y);
 
         // Now perform upgrade
-        UnreleasedOprfKeyRegistryV2 implementationV2 = new UnreleasedOprfKeyRegistryV2();
+        OprfKeyRegistryV2 implementationV2 = new OprfKeyRegistryV2();
         // upgrade as owner
         OprfKeyRegistry(address(proxy)).upgradeToAndCall(address(implementationV2), "");
         // Wrap proxy with V2 interface
-        UnreleasedOprfKeyRegistryV2 oprfKeyRegistryV2 = UnreleasedOprfKeyRegistryV2(address(proxy));
+        OprfKeyRegistryV2 oprfKeyRegistryV2 = OprfKeyRegistryV2(address(proxy));
 
         // Verify storage was preserved
         BabyJubJub.Affine memory oprfKeyV2 = oprfKeyRegistryV2.getOprfPublicKey(oprfKeyId);
@@ -164,7 +164,7 @@ contract OprfKeyRegistryUpgradeTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IUnreleasedOprfKeyRegistryV2.KeyGenStuckReported(stuckOprfKeyId, alice, OprfKeyGen.Round.ONE);
+        emit IOprfKeyRegistryV2.KeyGenStuckReported(stuckOprfKeyId, alice, OprfKeyGen.Round.ONE);
         oprfKeyRegistryV2.reportKeyGenStuck(stuckOprfKeyId);
         vm.stopPrank();
 
@@ -256,12 +256,12 @@ contract OprfKeyRegistryUpgradeTest is Test {
         IERC165(address(proxy)).supportsInterface(type(IERC165).interfaceId);
 
         // Now perform upgrade
-        UnreleasedOprfKeyRegistryV2 implementationV2 = new UnreleasedOprfKeyRegistryV2();
+        OprfKeyRegistryV2 implementationV2 = new OprfKeyRegistryV2();
         OprfKeyRegistry(address(proxy)).upgradeToAndCall(address(implementationV2), "");
-        UnreleasedOprfKeyRegistryV2 oprfKeyRegistryV2 = UnreleasedOprfKeyRegistryV2(address(proxy));
+        OprfKeyRegistryV2 oprfKeyRegistryV2 = OprfKeyRegistryV2(address(proxy));
 
         assertTrue(oprfKeyRegistryV2.supportsInterface(type(IOprfKeyRegistry).interfaceId));
-        assertTrue(oprfKeyRegistryV2.supportsInterface(type(IUnreleasedOprfKeyRegistryV2).interfaceId));
+        assertTrue(oprfKeyRegistryV2.supportsInterface(type(IOprfKeyRegistryV2).interfaceId));
         assertTrue(oprfKeyRegistryV2.supportsInterface(type(IERC165).interfaceId));
         assertFalse(oprfKeyRegistryV2.supportsInterface(0xffffffff));
     }

--- a/test/OprfKeyRegistryUpgradeV2.t.sol
+++ b/test/OprfKeyRegistryUpgradeV2.t.sol
@@ -4,14 +4,14 @@ pragma solidity ^0.8.20;
 import {Contributions} from "./Contributions.t.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IOprfKeyRegistry} from "../src/IOprfKeyRegistry.sol";
-import {IUnreleasedOprfKeyRegistryV2} from "../src/IUnreleasedOprfKeyRegistryV2.sol";
+import {IOprfKeyRegistryV2} from "../src/IOprfKeyRegistryV2.sol";
 import {OprfKeyGen} from "../src/OprfKeyGen.sol";
 import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
-import {UnreleasedOprfKeyRegistryV2} from "../src/UnreleasedOprfKeyRegistryV2.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 import {Test} from "forge-std/Test.sol";
 import {Verifier as VerifierKeyGen13} from "../src/VerifierKeyGen13.sol";
 
-contract OprfKeyRegistryV3Mock is UnreleasedOprfKeyRegistryV2 {
+contract OprfKeyRegistryV3Mock is OprfKeyRegistryV2 {
     uint256 public newFeature;
 
     function version() public pure returns (string memory) {
@@ -27,7 +27,7 @@ contract OprfKeyRegistryUpgradeV2Test is Test {
     uint256 public constant THRESHOLD = 2;
     uint256 public constant MAX_PEERS = 3;
 
-    UnreleasedOprfKeyRegistryV2 public oprfKeyRegistryV2;
+    OprfKeyRegistryV2 public oprfKeyRegistryV2;
     VerifierKeyGen13 public verifierKeyGen;
     ERC1967Proxy public proxy;
 
@@ -39,12 +39,12 @@ contract OprfKeyRegistryUpgradeV2Test is Test {
 
     function setUp() public {
         verifierKeyGen = new VerifierKeyGen13();
-        UnreleasedOprfKeyRegistryV2 implementationV2 = new UnreleasedOprfKeyRegistryV2();
+        OprfKeyRegistryV2 implementationV2 = new OprfKeyRegistryV2();
         bytes memory initData = abi.encodeWithSelector(
             OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         proxy = new ERC1967Proxy(address(implementationV2), initData);
-        oprfKeyRegistryV2 = UnreleasedOprfKeyRegistryV2(address(proxy));
+        oprfKeyRegistryV2 = OprfKeyRegistryV2(address(proxy));
 
         address[] memory peerAddresses = new address[](3);
         peerAddresses[0] = alice;
@@ -60,7 +60,7 @@ contract OprfKeyRegistryUpgradeV2Test is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IUnreleasedOprfKeyRegistryV2.KeyGenStuckReported(oprfKeyId, alice, OprfKeyGen.Round.ONE);
+        emit IOprfKeyRegistryV2.KeyGenStuckReported(oprfKeyId, alice, OprfKeyGen.Round.ONE);
         oprfKeyRegistryV2.reportKeyGenStuck(oprfKeyId);
 
         OprfKeyRegistryV3Mock implementationV3 = new OprfKeyRegistryV3Mock();

--- a/test/OprfKeyRegistryV2.t.sol
+++ b/test/OprfKeyRegistryV2.t.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.20;
 import {Contributions} from "./Contributions.t.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IOprfKeyRegistry} from "../src/IOprfKeyRegistry.sol";
-import {IUnreleasedOprfKeyRegistryV2} from "../src/IUnreleasedOprfKeyRegistryV2.sol";
+import {IOprfKeyRegistryV2} from "../src/IOprfKeyRegistryV2.sol";
 import {OprfKeyGen} from "../src/OprfKeyGen.sol";
 import {OprfKeyRegistry} from "../src/OprfKeyRegistry.sol";
-import {UnreleasedOprfKeyRegistryV2} from "../src/UnreleasedOprfKeyRegistryV2.sol";
+import {OprfKeyRegistryV2} from "../src/OprfKeyRegistryV2.sol";
 import {Test} from "forge-std/Test.sol";
 import {Verifier as VerifierKeyGen13} from "../src/VerifierKeyGen13.sol";
 
@@ -15,7 +15,7 @@ contract OprfKeyRegistryV2Test is Test {
     uint256 public constant THRESHOLD = 2;
     uint256 public constant MAX_PEERS = 3;
 
-    UnreleasedOprfKeyRegistryV2 public oprfKeyRegistry;
+    OprfKeyRegistryV2 public oprfKeyRegistry;
     VerifierKeyGen13 public verifierKeyGen;
     ERC1967Proxy public proxy;
 
@@ -27,12 +27,12 @@ contract OprfKeyRegistryV2Test is Test {
 
     function setUp() public {
         verifierKeyGen = new VerifierKeyGen13();
-        UnreleasedOprfKeyRegistryV2 implementation = new UnreleasedOprfKeyRegistryV2();
+        OprfKeyRegistryV2 implementation = new OprfKeyRegistryV2();
         bytes memory initData = abi.encodeWithSelector(
             OprfKeyRegistry.initialize.selector, initOwner, taceoAdmin, verifierKeyGen, THRESHOLD, MAX_PEERS
         );
         proxy = new ERC1967Proxy(address(implementation), initData);
-        oprfKeyRegistry = UnreleasedOprfKeyRegistryV2(address(proxy));
+        oprfKeyRegistry = OprfKeyRegistryV2(address(proxy));
 
         address[] memory peerAddresses = new address[](3);
         peerAddresses[0] = alice;
@@ -49,7 +49,7 @@ contract OprfKeyRegistryV2Test is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IUnreleasedOprfKeyRegistryV2.KeyGenStuckReported(oprfKeyId, alice, OprfKeyGen.Round.ONE);
+        emit IOprfKeyRegistryV2.KeyGenStuckReported(oprfKeyId, alice, OprfKeyGen.Round.ONE);
         oprfKeyRegistry.reportKeyGenStuck(oprfKeyId);
 
         // Bob tries to add his contribution but the round is stuck


### PR DESCRIPTION
- **ci: prepare release**
- **build: rename v2 contracts**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default deploy scripts now ship the V2 implementation for new proxies, which affects on-chain deployment choices; contract logic is largely a rename of already-staged V2 behavior.
> 
> **Overview**
> Prepares **OprfKeyRegistry V2** for release by dropping the `Unreleased` prefix (`OprfKeyRegistryV2`, `IOprfKeyRegistryV2`) and updating deploy scripts, tests, and NatSpec so **fresh proxy deployments** use the V2 implementation while still initializing via `OprfKeyRegistry.initialize`.
> 
> Adds **release tooling**: `cliff.toml` and a generated `CHANGELOG.md`, `just changelog`, `RELEASING.md` (UUPS staging/tag/upgrade steps), and a **tag-triggered** `.github/workflows/release.yml` that builds GitHub Release notes with git-cliff and publishes via `action-gh-release`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3fb7c7b43f0174cb0678a628cb44797b186fd34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->