### PR TITLE
ci: update release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,26 +9,51 @@ on:
 
 jobs:
   release:
-    name: Create GitHub Release
+    name: Update changelog and create GitHub Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Update CHANGELOG.md
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
+        with:
+          config: cliff.toml
+          args: --tag ${{ github.ref_name }}
+        env:
+          OUTPUT: CHANGELOG.md
+
+      - name: Open changelog PR
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          base: main
+          branch: changelog/${{ github.ref_name }}
+          title: "chore: update changelog for ${{ github.ref_name }}"
+          commit-message: "chore: update changelog for ${{ github.ref_name }}"
+          add-paths: CHANGELOG.md
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.ref_name }}
           persist-credentials: false
           fetch-depth: 0
 
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
-          args: --latest --strip header
+          args: --current --strip header
         env:
           OUTPUT: RELEASE_NOTES.md
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           body_path: RELEASE_NOTES.md


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only changes to release automation; no application runtime or contract behavior is affected.
> 
> **Overview**
> The **release** workflow on version tags now **updates `CHANGELOG.md` on `main`** with git-cliff (`--tag` for the pushed tag), then **opens a PR** (`changelog/<tag>`) via `create-pull-request` instead of only publishing a GitHub Release.
> 
> Release publishing is split into two checkouts: changelog work uses **`main`** with full history; **release notes and the GitHub Release** use a second checkout at **`${{ github.ref_name }}`**. Release notes generation switches from **`--latest`** to **`--current`**, and third-party actions are **pinned to commit SHAs**. The job gains **`pull-requests: write`** alongside **`contents: write`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59412937a638454ec3603c85ffcf65c8582ccb96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->